### PR TITLE
Use asynchronous code instead of synchronous code

### DIFF
--- a/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
+++ b/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1.1</ReleaseVersion>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="NLog" Version="4.7.6" />
     <PackageReference Include="AWSSDK.QLDB" Version="3.5.0.57" />
-    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Amazon.QLDB.Driver.IntegrationTests/StatementExecutionTests.cs
+++ b/Amazon.QLDB.Driver.IntegrationTests/StatementExecutionTests.cs
@@ -838,8 +838,8 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
                     Assert.IsNotNull(ioUsage);
                     Assert.IsNotNull(timingInfo);
-                    Assert.IsTrue(ioUsage.ReadIOs > 0);
-                    Assert.IsTrue(timingInfo.ProcessingTimeMilliseconds > 0);
+                    Assert.IsTrue(ioUsage?.ReadIOs > 0);
+                    Assert.IsTrue(timingInfo?.ProcessingTimeMilliseconds > 0);
                 }
             });
 
@@ -854,8 +854,8 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             Assert.IsNotNull(ioUsage);
             Assert.IsNotNull(timingInfo);
-            Assert.AreEqual(1092, ioUsage.ReadIOs);
-            Assert.IsTrue(timingInfo.ProcessingTimeMilliseconds > 0);
+            Assert.AreEqual(1092, ioUsage?.ReadIOs);
+            Assert.IsTrue(timingInfo?.ProcessingTimeMilliseconds > 0);
         }
 
         public static IEnumerable<object[]> CreateIonValues()

--- a/Amazon.QLDB.Driver.IntegrationTests/StatementExecutionTests.cs
+++ b/Amazon.QLDB.Driver.IntegrationTests/StatementExecutionTests.cs
@@ -23,6 +23,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
 
     [TestClass]
@@ -34,7 +35,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         private static QldbDriver qldbDriver;
 
         [ClassInitialize]
-        public static void SetUp(TestContext context)
+        public static async Task SetUp(TestContext context)
         {
             // Get AWS configuration properties from .runsettings file.
             string region = context.Properties["region"].ToString();
@@ -49,12 +50,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // Create table.
             var query = $"CREATE TABLE {Constants.TableName}";
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query);
+                var result = await txn.Execute(query);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -62,7 +63,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             });
             Assert.AreEqual(1, count);
 
-            var result = qldbDriver.ListTableNames();
+            var result = await qldbDriver.ListTableNames();
             foreach (var row in result)
             {
                 Assert.AreEqual(Constants.TableName, row);
@@ -70,30 +71,30 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [ClassCleanup]
-        public static void ClassCleanup()
+        public static async Task ClassCleanup()
         {
             integrationTestBase.RunDeleteLedger();
-            qldbDriver.Dispose();
+            await qldbDriver.DisposeAsync();
         }
 
         [TestCleanup]
-        public void TestCleanup()
+        public async Task TestCleanup()
         {
             // Delete all documents in table.
-            qldbDriver.Execute(txn => txn.Execute($"DELETE FROM {Constants.TableName}"));
+            await qldbDriver.Execute(async txn => await txn.Execute($"DELETE FROM {Constants.TableName}"));
         }
 
         [TestMethod]
-        public void Execute_DropExistingTable_TableDropped()
+        public async Task Execute_DropExistingTable_TableDropped()
         {
             // Given.
             var create_table_query = $"CREATE TABLE {Constants.CreateTableName}";
-            var create_table_count = qldbDriver.Execute(txn =>
+            var create_table_count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(create_table_query);
+                var result = await txn.Execute(create_table_query);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -102,7 +103,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             Assert.AreEqual(1, create_table_count);
 
             // Execute ListTableNames() to ensure table is created.
-            var result = qldbDriver.ListTableNames();
+            var result = await qldbDriver.ListTableNames();
 
             var tables = new List<string>();
             foreach (var row in result)
@@ -113,12 +114,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // When.
             var drop_table_query = $"DROP TABLE {Constants.CreateTableName}";
-            var drop_table_count = qldbDriver.Execute(txn =>
+            var drop_table_count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(drop_table_query);
+                var result = await txn.Execute(drop_table_query);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -128,7 +129,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // Then.
             tables.Clear();
-            var updated_tables_result = qldbDriver.ListTableNames();
+            var updated_tables_result = await qldbDriver.ListTableNames();
             foreach (var row in updated_tables_result)
             {
                 tables.Add(row);
@@ -137,10 +138,10 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_ListTables_ReturnsListOfTables()
+        public async Task Execute_ListTables_ReturnsListOfTables()
         {
             // When.
-            var result = qldbDriver.ListTableNames();
+            var result = await qldbDriver.ListTableNames();
 
             // Then.
             int count = 0;
@@ -154,29 +155,44 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
+        public async Task Execute_ListTables_IsCancelled()
+        {
+            // Given
+            var cts = new CancellationTokenSource();
+            var cancellationToken = cts.Token;
+            cts.Cancel();
+
+            // When.
+            Func<Task> act = () => qldbDriver.ListTableNames(cancellationToken);
+
+            // Then.
+            await Assert.ThrowsExceptionAsync<TaskCanceledException>(act);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(BadRequestException))]
-        public void Execute_CreateTableThatAlreadyExist_ThrowBadRequestException()
+        public async Task Execute_CreateTableThatAlreadyExist_ThrowBadRequestException()
         {
             // Given.
             var query = $"CREATE TABLE {Constants.TableName}";
 
             // When.
-            qldbDriver.Execute(txn => txn.Execute(query));
+            await qldbDriver.Execute(async txn => await txn.Execute(query));
         }
 
         [TestMethod]
-        public void Execute_CreateIndex_IndexIsCreated()
+        public async Task Execute_CreateIndex_IndexIsCreated()
         {
             // Given.
             var query = $"CREATE INDEX on {Constants.TableName} ({Constants.IndexAttribute})";
 
             // When.
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query);
+                var result = await txn.Execute(query);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -187,9 +203,9 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             // Then.
             var search_query = $@"SELECT VALUE indexes[0] FROM information_schema.user_tables
                                   WHERE status = 'ACTIVE' AND name = '{Constants.TableName}'";
-            var indexColumn = qldbDriver.Execute(txn =>
+            var indexColumn = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(search_query);
+                var result = await txn.Execute(search_query);
 
                 // Extract the index name by querying the information_schema.
                 /* This gives:
@@ -198,7 +214,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
                 }
                 */
                 var indexColumn = "";
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     indexColumn = row.GetField("expr").StringValue;
                 }
@@ -209,18 +225,18 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_QueryTableThatHasNoRecords_ReturnsEmptyResult()
+        public async Task Execute_QueryTableThatHasNoRecords_ReturnsEmptyResult()
         {
             // Given.
             var query = $"SELECT * FROM {Constants.TableName}";
 
             // When.
-            int resultSetSize = qldbDriver.Execute(txn =>
+            int resultSetSize = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query);
+                var result = await txn.Execute(query);
 
                 int count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -232,7 +248,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_InsertDocument_DocumentIsInserted()
+        public async Task Execute_InsertDocument_DocumentIsInserted()
         {
             // Given.
             // Create Ion struct to insert.
@@ -241,12 +257,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // When.
             var query = $"INSERT INTO {Constants.TableName} ?";
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query, ionStruct);
+                var result = await txn.Execute(query, ionStruct);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -257,12 +273,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             // Then.
             var searchQuery = $@"SELECT VALUE {Constants.ColumnName} FROM {Constants.TableName} 
                                WHERE {Constants.ColumnName} = '{Constants.SingleDocumentValue}'";
-            var value = qldbDriver.Execute(txn =>
+            var value = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(searchQuery);
+                var result = await txn.Execute(searchQuery);
 
                 var value = "";
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     value = row.StringValue;
                 }
@@ -272,7 +288,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_InsertDocumentWithMultipleFields_DocumentIsInserted()
+        public async Task Execute_InsertDocumentWithMultipleFields_DocumentIsInserted()
         {
             // Given.
             // Create Ion struct to insert.
@@ -282,12 +298,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // When.
             var query = $"INSERT  INTO {Constants.TableName} ?";
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query, ionStruct);
+                var result = await txn.Execute(query, ionStruct);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -298,12 +314,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             // Then.
             var searchQuery = $@"SELECT {Constants.ColumnName}, {Constants.SecondColumnName} FROM {Constants.TableName} 
                                WHERE {Constants.ColumnName} = '{Constants.SingleDocumentValue}' AND  {Constants.SecondColumnName} = '{Constants.SingleDocumentValue}'";
-            IIonValue value = qldbDriver.Execute(txn =>
+            IIonValue value = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(searchQuery);
+                var result = await txn.Execute(searchQuery);
 
                 IIonValue value = null;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     value = row;
                 }
@@ -322,7 +338,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_QuerySingleField_ReturnsSingleField()
+        public async Task Execute_QuerySingleField_ReturnsSingleField()
         {
             // Given.
             // Create Ion struct to insert.
@@ -330,12 +346,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             ionStruct.SetField(Constants.ColumnName, ValueFactory.NewString(Constants.SingleDocumentValue));
 
             var query = $"INSERT INTO {Constants.TableName} ?";
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query, ionStruct);
+                var result = await txn.Execute(query, ionStruct);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -346,12 +362,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             // When.
             var searchQuery = $@"SELECT VALUE {Constants.ColumnName} FROM {Constants.TableName}
                                  WHERE {Constants.ColumnName} = '{Constants.SingleDocumentValue}'";
-            var value = qldbDriver.Execute(txn =>
+            var value = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(searchQuery);
+                var result = await txn.Execute(searchQuery);
 
                 var value = "";
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     value = row.StringValue;
                 }
@@ -363,7 +379,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_QueryTableEnclosedInQuotes_ReturnsResult()
+        public async Task Execute_QueryTableEnclosedInQuotes_ReturnsResult()
         {
             // Given.
             // Create Ion struct to insert.
@@ -371,12 +387,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             ionStruct.SetField(Constants.ColumnName, ValueFactory.NewString(Constants.SingleDocumentValue));
 
             var query = $"INSERT INTO {Constants.TableName} ?";
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query, ionStruct);
+                var result = await txn.Execute(query, ionStruct);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -387,12 +403,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             // When.
             var searchQuery = $@"SELECT VALUE {Constants.ColumnName} FROM ""{Constants.TableName}""
                                  WHERE {Constants.ColumnName} = '{Constants.SingleDocumentValue}'";
-            var value = qldbDriver.Execute(txn =>
+            var value = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(searchQuery);
+                var result = await txn.Execute(searchQuery);
 
                 var value = "";
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     value = row.StringValue;
                 }
@@ -404,7 +420,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_InsertMultipleDocuments_DocumentsInserted()
+        public async Task Execute_InsertMultipleDocuments_DocumentsInserted()
         {
             IIonValue ionString1 = ValueFactory.NewString(Constants.MultipleDocumentValue1);
             IIonValue ionString2 = ValueFactory.NewString(Constants.MultipleDocumentValue2);
@@ -421,12 +437,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // When.
             var query = $"INSERT INTO {Constants.TableName} <<?,?>>";
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query, parameters);
+                var result = await txn.Execute(query, parameters);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -437,12 +453,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             // Then.
             var searchQuery = $@"SELECT VALUE {Constants.ColumnName} FROM {Constants.TableName}
                                  WHERE {Constants.ColumnName} IN (?,?)";
-            var values = qldbDriver.Execute(txn =>
+            var values = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(searchQuery, ionString1, ionString2);
+                var result = await txn.Execute(searchQuery, ionString1, ionString2);
 
                 var values = new List<String>();
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     values.Add(row.StringValue);
                 }
@@ -453,7 +469,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_DeleteSingleDocument_DocumentIsDeleted()
+        public async Task Execute_DeleteSingleDocument_DocumentIsDeleted()
         {
             // Given.
             // Create Ion struct to insert.
@@ -461,12 +477,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             ionStruct.SetField(Constants.ColumnName, ValueFactory.NewString(Constants.SingleDocumentValue));
 
             var query = $"INSERT INTO {Constants.TableName} ?";
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query, ionStruct);
+                var result = await txn.Execute(query, ionStruct);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -477,12 +493,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             // When.
             var deleteQuery = $@"DELETE FROM { Constants.TableName}
                                  WHERE {Constants.ColumnName} = '{Constants.SingleDocumentValue}'";
-            var deletedCount = qldbDriver.Execute(txn =>
+            var deletedCount = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(deleteQuery);
+                var result = await txn.Execute(deleteQuery);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -492,12 +508,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // Then.
             var searchQuery = $"SELECT COUNT(*) FROM {Constants.TableName}";
-            var searchCount = qldbDriver.Execute(txn =>
+            var searchCount = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(searchQuery);
+                var result = await txn.Execute(searchQuery);
 
                 int count = -1;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     // This gives:
                     // {
@@ -512,7 +528,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_DeleteAllDocuments_DocumentsAreDeleted()
+        public async Task Execute_DeleteAllDocuments_DocumentsAreDeleted()
         {
             // Given.
             // Create Ion structs to insert.
@@ -525,12 +541,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             List<IIonValue> parameters = new List<IIonValue>() { ionStruct1, ionStruct2 };
 
             var query = $"INSERT INTO {Constants.TableName} <<?,?>>";
-            var count = qldbDriver.Execute(txn =>
+            var count = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query, parameters);
+                var result = await txn.Execute(query, parameters);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -540,12 +556,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // When.
             var deleteQuery = $"DELETE FROM { Constants.TableName}";
-            var deleteCount = qldbDriver.Execute(txn =>
+            var deleteCount = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(deleteQuery);
+                var result = await txn.Execute(deleteQuery);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -555,12 +571,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // Then.
             var searchQuery = $"SELECT COUNT(*) FROM {Constants.TableName}";
-            var searchCount = qldbDriver.Execute(txn =>
+            var searchCount = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(searchQuery);
+                var result = await txn.Execute(searchQuery);
 
                 int count = -1;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     // This gives:
                     // {
@@ -576,7 +592,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
         [TestMethod]
         [ExpectedException(typeof(OccConflictException))]
-        public void Execute_UpdateSameRecordAtSameTime_ThrowsOccException()
+        public async Task Execute_UpdateSameRecordAtSameTime_ThrowsOccException()
         {
             // Create a driver that does not retry OCC errors
             QldbDriver driver = integrationTestBase.CreateDriver(amazonQldbSessionConfig, default, default, 0);
@@ -587,12 +603,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             ionStruct.SetField(Constants.ColumnName, ValueFactory.NewInt(0));
 
             var query = $"INSERT INTO {Constants.TableName} ?";
-            var count = driver.Execute(txn =>
+            var count = await driver.Execute(async txn =>
             {
-                var result = txn.Execute(query, ionStruct);
+                var result = await txn.Execute(query, ionStruct);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -605,29 +621,29 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // For testing purposes only. Forcefully causes an OCC conflict to occur.
             // Do not invoke QldbDriver.Execute within the lambda function under normal circumstances.
-            driver.Execute(txn =>
+            await driver.Execute(async txn =>
             {
                 // Query table.
-                var result = txn.Execute(selectQuery);
+                var result = await txn.Execute(selectQuery);
 
                 var currentValue = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     currentValue = row.IntValue;
                 }
 
-                driver.Execute(txn =>
+                await driver.Execute(async txn =>
                 {
                     // Update document.
                     var ionValue = ValueFactory.NewInt(currentValue + 5);
-                    txn.Execute(updateQuery, ionValue);
+                    await txn.Execute(updateQuery, ionValue);
                 }, RetryPolicy.Builder().WithMaxRetries(0).Build());
             }, RetryPolicy.Builder().WithMaxRetries(0).Build());
         }
 
         [TestMethod]
         [DynamicData(nameof(CreateIonValues), DynamicDataSourceType.Method)]
-        public void Execute_InsertAndReadIonTypes_IonTypesAreInsertedAndRead(IIonValue ionValue)
+        public async Task Execute_InsertAndReadIonTypes_IonTypesAreInsertedAndRead(IIonValue ionValue)
         {
             // Given.
             // Create Ion struct to be inserted.
@@ -635,12 +651,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             ionStruct.SetField(Constants.ColumnName, ionValue);
 
             var query = $"INSERT INTO {Constants.TableName} ?";
-            var insertCount = qldbDriver.Execute(txn =>
+            var insertCount = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(query, ionStruct);
+                var result = await txn.Execute(query, ionStruct);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -654,12 +670,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             {
                 var searchQuery = $@"SELECT VALUE { Constants.ColumnName } FROM { Constants.TableName }
                                      WHERE { Constants.ColumnName } IS NULL";
-                searchResult = qldbDriver.Execute(txn =>
+                searchResult = await qldbDriver.Execute(async txn =>
                 {
-                    var result = txn.Execute(searchQuery);
+                    var result = await txn.Execute(searchQuery);
 
                     IIonValue ionVal = null;
-                    foreach (var row in result)
+                    await foreach (var row in result)
                     {
                         ionVal = row;
                     }
@@ -670,12 +686,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             {
                 var searchQuery = $@"SELECT VALUE { Constants.ColumnName } FROM { Constants.TableName }
                                      WHERE { Constants.ColumnName } = ?";
-                searchResult = qldbDriver.Execute(txn =>
+                searchResult = await qldbDriver.Execute(async txn =>
                 {
-                    var result = txn.Execute(searchQuery, ionValue);
+                    var result = await txn.Execute(searchQuery, ionValue);
 
                     IIonValue ionVal = null;
-                    foreach (var row in result)
+                    await foreach (var row in result)
                     {
                         ionVal = row;
                     }
@@ -693,7 +709,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
         [TestMethod]
         [DynamicData(nameof(CreateIonValues), DynamicDataSourceType.Method)]
-        public void Execute_UpdateIonTypes_IonTypesAreUpdated(IIonValue ionValue)
+        public async Task Execute_UpdateIonTypes_IonTypesAreUpdated(IIonValue ionValue)
         {
             // Given.
             // Create Ion struct to be inserted.
@@ -702,12 +718,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // Insert first record which will be subsequently updated.
             var insertQuery = $"INSERT INTO {Constants.TableName} ?";
-            var insertCount = qldbDriver.Execute(txn =>
+            var insertCount = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(insertQuery, ionStruct);
+                var result = await txn.Execute(insertQuery, ionStruct);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -717,12 +733,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // When.
             var updateQuery = $"UPDATE { Constants.TableName } SET { Constants.ColumnName } = ?";
-            var updateCount = qldbDriver.Execute(txn =>
+            var updateCount = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(updateQuery, ionValue);
+                var result = await txn.Execute(updateQuery, ionValue);
 
                 var count = 0;
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     count++;
                 }
@@ -736,12 +752,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             {
                 var searchQuery = $@"SELECT VALUE { Constants.ColumnName } FROM { Constants.TableName }
                                      WHERE { Constants.ColumnName } IS NULL";
-                searchResult = qldbDriver.Execute(txn =>
+                searchResult = await qldbDriver.Execute(async txn =>
                 {
-                    var result = txn.Execute(searchQuery);
+                    var result = await txn.Execute(searchQuery);
 
                     IIonValue ionVal = null;
-                    foreach (var row in result)
+                    await foreach (var row in result)
                     {
                         ionVal = row;
                     }
@@ -752,12 +768,12 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             {
                 var searchQuery = $@"SELECT VALUE { Constants.ColumnName } FROM { Constants.TableName }
                                      WHERE { Constants.ColumnName } = ?";
-                searchResult = qldbDriver.Execute(txn =>
+                searchResult = await qldbDriver.Execute(async txn =>
                 {
-                    var result = txn.Execute(searchQuery, ionValue);
+                    var result = await txn.Execute(searchQuery, ionValue);
 
                     IIonValue ionVal = null;
-                    foreach (var row in result)
+                    await foreach (var row in result)
                     {
                         ionVal = row;
                     }
@@ -773,7 +789,7 @@ namespace Amazon.QLDB.Driver.IntegrationTests
         }
 
         [TestMethod]
-        public void Execute_ExecuteLambdaThatDoesNotReturnValue_RecordIsUpdated()
+        public async Task Execute_ExecuteLambdaThatDoesNotReturnValue_RecordIsUpdated()
         {
             // Given.
             // Create Ion struct to insert.
@@ -782,17 +798,17 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             // When.
             var query = $"INSERT INTO {Constants.TableName} ?";
-            qldbDriver.Execute(txn => txn.Execute(query, ionStruct));
+            await qldbDriver.Execute(async txn => await txn.Execute(query, ionStruct));
 
             // Then.
             var searchQuery = $@"SELECT VALUE {Constants.ColumnName} FROM {Constants.TableName}
                                  WHERE {Constants.ColumnName} = '{Constants.SingleDocumentValue}'";
-            var value = qldbDriver.Execute(txn =>
+            var value = await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(searchQuery);
+                var result = await txn.Execute(searchQuery);
 
                 string value = "";
-                foreach (var row in result)
+                await foreach (var row in result)
                 {
                     value = row.StringValue;
                 }
@@ -803,23 +819,23 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
         [TestMethod]
         [ExpectedException(typeof(BadRequestException))]
-        public void Execute_DeleteTableThatDoesntExist_ThrowsBadRequestException()
+        public async Task Execute_DeleteTableThatDoesntExist_ThrowsBadRequestException()
         {
             // Given.
             var query = "DELETE FROM NonExistentTable";
 
             // When.
-            qldbDriver.Execute(txn => txn.Execute(query));
+            await qldbDriver.Execute(async txn => await txn.Execute(query));
         }
 
         [TestMethod]
-        public void Execute_ExecutionMetrics()
+        public async Task Execute_ExecutionMetrics()
         {
-            qldbDriver.Execute(txn =>
+            await qldbDriver.Execute(async txn =>
             {
                 var insertQuery = String.Format("INSERT INTO {0} << {{'col': 1}}, {{'col': 2}}, {{'col': 3}} >>",
                     Constants.TableName);
-                txn.Execute(insertQuery);
+                await txn.Execute(insertQuery);
             });
 
             // Given
@@ -827,11 +843,11 @@ namespace Amazon.QLDB.Driver.IntegrationTests
                 Constants.TableName);
 
             // When
-            qldbDriver.Execute(txn =>
+            await qldbDriver.Execute(async txn =>
             {
-                var result = txn.Execute(selectQuery);
+                var result = await txn.Execute(selectQuery);
 
-                foreach (IIonValue row in result)
+                await foreach (IIonValue row in result)
                 {
                     var ioUsage = result.GetConsumedIOs();
                     var timingInfo = result.GetTimingInformation();
@@ -844,9 +860,9 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             });
 
             // When
-            var result = qldbDriver.Execute(txn =>
+            var result = await qldbDriver.Execute(async txn =>
             {
-                return txn.Execute(selectQuery);
+                return await txn.Execute(selectQuery);
             });
 
             var ioUsage = result.GetConsumedIOs();

--- a/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.csproj
+++ b/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
-    <ReleaseVersion>1.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1.1</ReleaseVersion>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 

--- a/Amazon.QLDB.Driver.Tests/BufferedResultTests.cs
+++ b/Amazon.QLDB.Driver.Tests/BufferedResultTests.cs
@@ -14,6 +14,8 @@
 namespace Amazon.QLDB.Driver.Tests
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Amazon.IonDotnet.Tree;
     using Amazon.IonDotnet.Tree.Impl;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -32,7 +34,7 @@ namespace Amazon.QLDB.Driver.Tests
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
-        public static void SetupClass(TestContext context)
+        public static async Task SetupClass(TestContext context)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
             mockResult = new Mock<IResult>();
@@ -44,18 +46,18 @@ namespace Amazon.QLDB.Driver.Tests
             };
             testIO = new IOUsage(1, 2);
             testTiming = new TimingInformation(100);
-            mockResult.Setup(x => x.GetEnumerator()).Returns(testList.GetEnumerator());
+            mockResult.Setup(x => x.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(new ValuesEnumerator(testList));
             mockResult.Setup(x => x.GetConsumedIOs()).Returns(testIO);
             mockResult.Setup(x => x.GetTimingInformation()).Returns(testTiming);
 
-            result = BufferedResult.BufferResult(mockResult.Object);
+            result = await BufferedResult.BufferResult(mockResult.Object);
         }
 
         [TestMethod]
         public void TestBufferResultEnumeratesInput()
         {
             Assert.IsNotNull(result);
-            mockResult.Verify(x => x.GetEnumerator(), Times.Exactly(1));
+            mockResult.Verify(x => x.GetAsyncEnumerator(default), Times.Exactly(1));
         }
 
         [TestMethod]
@@ -68,16 +70,29 @@ namespace Amazon.QLDB.Driver.Tests
         }
 
         [TestMethod]
-        public void TestGetEnumeratorGetsAllInputEnumerableValues()
+        public async Task TestGetEnumeratorGetsAllInputEnumerableValues()
         {
             int count = 0;
-            var enumerator = result.GetEnumerator();
-            while (enumerator.MoveNext())
+            var enumerator = result.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 Assert.AreEqual(count, enumerator.Current.IntValue);
                 count++;
             }
             Assert.AreEqual(testList.Count, count);
+        }
+
+        private struct ValuesEnumerator : IAsyncEnumerator<IIonValue>
+        {
+            private List<IIonValue>.Enumerator valuesEnumerator;
+
+            public ValuesEnumerator(List<IIonValue> values) => this.valuesEnumerator = values.GetEnumerator();
+
+            public IIonValue Current => this.valuesEnumerator.Current;
+
+            public ValueTask<bool> MoveNextAsync() => new ValueTask<bool>(this.valuesEnumerator.MoveNext());
+
+            public ValueTask DisposeAsync() => default;
         }
     }
 }

--- a/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
@@ -16,6 +16,7 @@ namespace Amazon.QLDB.Driver.Tests
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Amazon.QLDBSession;
@@ -388,7 +389,7 @@ namespace Amazon.QLDB.Driver.Tests
             return new List<object[]>() {
                 new object[] { new InvalidSessionException("invalid session"), false },
                 new object[] { new OccConflictException("occ"), false },
-                new object[] { new CapacityExceededException("capacity exceeded"), false },
+                new object[] { new CapacityExceededException("capacity exceeded", ErrorType.Receiver, "errorCode", "requestId", HttpStatusCode.ServiceUnavailable), false },
                 new object[] { new ArgumentException(), true },
                 new object[] { new QldbDriverException("generic"), true },
             };

--- a/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
@@ -388,8 +388,9 @@ namespace Amazon.QLDB.Driver.Tests
             return new List<object[]>() {
                 new object[] { new InvalidSessionException("invalid session"), false },
                 new object[] { new OccConflictException("occ"), false },
+                new object[] { new CapacityExceededException("capacity exceeded"), false },
                 new object[] { new ArgumentException(), true },
-                new object[] { new QldbDriverException("generic"), true }
+                new object[] { new QldbDriverException("generic"), true },
             };
         }
     }

--- a/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
@@ -191,7 +191,7 @@ namespace Amazon.QLDB.Driver.Tests
         public static IEnumerable<object[]> CreateExceptionTestData()
         {
             return new List<object[]>() {
-                new object[] { new CapacityExceededException("Capacity Exceeded Exception"),
+                new object[] { new CapacityExceededException("Capacity Exceeded Exception", ErrorType.Receiver, "errorCode", "requestId", HttpStatusCode.ServiceUnavailable),
                     typeof(RetriableException), typeof(CapacityExceededException),
                     Times.Once()},
                 new object[] { new AmazonQLDBSessionException("", 0, "", "", HttpStatusCode.InternalServerError),
@@ -300,6 +300,7 @@ namespace Amazon.QLDB.Driver.Tests
                 new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.ServiceUnavailable) },
                 new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.Conflict) },
                 new object[] { new Exception("message")},
+                new object[] { new CapacityExceededException("message", ErrorType.Receiver, "errorCode", "requestId", HttpStatusCode.ServiceUnavailable) },
             };
         }
     }

--- a/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
@@ -191,6 +191,9 @@ namespace Amazon.QLDB.Driver.Tests
         public static IEnumerable<object[]> CreateExceptionTestData()
         {
             return new List<object[]>() {
+                new object[] { new CapacityExceededException("Capacity Exceeded Exception"),
+                    typeof(RetriableException), typeof(CapacityExceededException),
+                    Times.Once()},
                 new object[] { new AmazonQLDBSessionException("", 0, "", "", HttpStatusCode.InternalServerError),
                     typeof(RetriableException), null,
                     Times.Once()},

--- a/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
@@ -27,7 +27,6 @@ namespace Amazon.QLDB.Driver.Tests
     using Amazon.QLDBSession;
     using Amazon.QLDBSession.Model;
     using Amazon.Runtime;
-    using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
     using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -74,7 +73,7 @@ namespace Amazon.QLDB.Driver.Tests
 
         [DataTestMethod]
         [DynamicData(nameof(CreateExecuteTestData), DynamicDataSourceType.Method)]
-        public void Exectue_CustomerTransactionTest(Func<TransactionExecutor, Object> transaction, Object expected, Type expectedExceptionType, Type innerExceptionType,
+        public void Execute_CustomerTransactionTest(Func<TransactionExecutor, Object> transaction, Object expected, Type expectedExceptionType, Type innerExceptionType,
             Times startTxnTimes, Times executeTimes, Times commitTimes, Times abortTimes, Times retryTimes)
         {
             mockSession.Setup(x => x.StartTransaction()).Returns(new StartTransactionResult
@@ -250,6 +249,26 @@ namespace Amazon.QLDB.Driver.Tests
         }
 
         [TestMethod]
+        [DynamicData(nameof(CreateExceptions), DynamicDataSourceType.Method)]
+        public void Execute_StartTransactionThrowExceptions(Exception exception)
+        {
+            mockSession.Setup(x => x.StartTransaction()).Throws(exception);
+
+            if (exception.GetType() == typeof(Exception) ||
+                (exception.GetType() == typeof(AmazonServiceException) && ((AmazonServiceException)exception).StatusCode != HttpStatusCode.InternalServerError && ((AmazonServiceException)exception).StatusCode != HttpStatusCode.ServiceUnavailable))
+            {
+                Assert.ThrowsException<QldbTransactionException>(
+                    () => qldbSession.Execute(
+                        (TransactionExecutor txn) => { txn.Execute("testStatement"); return true; }));
+
+            } else {
+                Assert.ThrowsException<RetriableException>(
+                    () => qldbSession.Execute(
+                        (TransactionExecutor txn) => { txn.Execute("testStatement"); return true; }));
+            }
+        }
+
+        [TestMethod]
         public void TestStartTransactionReturnsANewTransaction()
         {
             mockSession.Setup(x => x.StartTransaction()).Returns(new StartTransactionResult
@@ -266,6 +285,19 @@ namespace Amazon.QLDB.Driver.Tests
             public virtual void DisposeDelegate(QldbSession session)
             {
             }
+        }
+
+        public static IEnumerable<Object[]> CreateExceptions()
+        {
+            return new List<object[]>()
+            {
+                new object[] { new InvalidSessionException("message") },
+                new object[] { new OccConflictException("message") },
+                new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.InternalServerError) },
+                new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.ServiceUnavailable) },
+                new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.Conflict) },
+                new object[] { new Exception("message")},
+            };
         }
     }
 }

--- a/Amazon.QLDB.Driver.Tests/ResultTests.cs
+++ b/Amazon.QLDB.Driver.Tests/ResultTests.cs
@@ -165,9 +165,8 @@ namespace Amazon.QLDB.Driver.Tests
 
             var io = result.GetConsumedIOs();
             var timing = result.GetTimingInformation();
-            Assert.IsNull(io.ReadIOs);
-            Assert.IsNull(io.WriteIOs);
-            Assert.IsNull(timing.ProcessingTimeMilliseconds);
+            Assert.IsNull(io);
+            Assert.IsNull(timing);
 
             var results = result.GetEnumerator();
             while (results.MoveNext())
@@ -177,9 +176,8 @@ namespace Amazon.QLDB.Driver.Tests
 
             io = result.GetConsumedIOs();
             timing = result.GetTimingInformation();
-            Assert.IsNull(io.ReadIOs);
-            Assert.IsNull(io.WriteIOs);
-            Assert.IsNull(timing.ProcessingTimeMilliseconds);
+            Assert.IsNull(io);
+            Assert.IsNull(timing);
         }
 
         [TestMethod]
@@ -195,9 +193,8 @@ namespace Amazon.QLDB.Driver.Tests
 
             var io = result.GetConsumedIOs();
             var timing = result.GetTimingInformation();
-            Assert.IsNull(io.ReadIOs);
-            Assert.IsNull(io.WriteIOs);
-            Assert.IsNull(timing.ProcessingTimeMilliseconds);
+            Assert.IsNull(io);
+            Assert.IsNull(timing);
 
             var results = result.GetEnumerator();
             while (results.MoveNext())
@@ -207,9 +204,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             io = result.GetConsumedIOs();
             timing = result.GetTimingInformation();
-            Assert.AreEqual(fetchReads, io.ReadIOs);
-            Assert.AreEqual(fetchWrites, io.WriteIOs);
-            Assert.AreEqual(fetchTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(fetchReads, io?.ReadIOs);
+            Assert.AreEqual(fetchWrites, io?.WriteIOs);
+            Assert.AreEqual(fetchTime, timing?.ProcessingTimeMilliseconds);
         }
 
         [TestMethod]
@@ -225,9 +222,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             var io = result.GetConsumedIOs();
             var timing = result.GetTimingInformation();
-            Assert.AreEqual(executeReads, io.ReadIOs);
-            Assert.AreEqual(executeWrites, io.WriteIOs);
-            Assert.AreEqual(executeTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(executeReads, io?.ReadIOs);
+            Assert.AreEqual(executeWrites, io?.WriteIOs);
+            Assert.AreEqual(executeTime, timing?.ProcessingTimeMilliseconds);
 
             var results = result.GetEnumerator();
             while (results.MoveNext())
@@ -237,9 +234,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             io = result.GetConsumedIOs();
             timing = result.GetTimingInformation();
-            Assert.AreEqual(executeReads, io.ReadIOs);
-            Assert.AreEqual(executeWrites, io.WriteIOs);
-            Assert.AreEqual(executeTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(executeReads, io?.ReadIOs);
+            Assert.AreEqual(executeWrites, io?.WriteIOs);
+            Assert.AreEqual(executeTime, timing?.ProcessingTimeMilliseconds);
         }
 
         [TestMethod]
@@ -255,9 +252,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             var io = result.GetConsumedIOs();
             var timing = result.GetTimingInformation();
-            Assert.AreEqual(executeReads, io.ReadIOs);
-            Assert.AreEqual(executeWrites, io.WriteIOs);
-            Assert.AreEqual(executeTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(executeReads, io?.ReadIOs);
+            Assert.AreEqual(executeWrites, io?.WriteIOs);
+            Assert.AreEqual(executeTime, timing?.ProcessingTimeMilliseconds);
 
             var results = result.GetEnumerator();
             while (results.MoveNext())
@@ -267,9 +264,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             io = result.GetConsumedIOs();
             timing = result.GetTimingInformation();
-            Assert.AreEqual(executeReads + fetchReads, io.ReadIOs);
-            Assert.AreEqual(executeWrites + fetchWrites, io.WriteIOs);
-            Assert.AreEqual(executeTime + fetchTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(executeReads + fetchReads, io?.ReadIOs);
+            Assert.AreEqual(executeWrites + fetchWrites, io?.WriteIOs);
+            Assert.AreEqual(executeTime + fetchTime, timing?.ProcessingTimeMilliseconds);
         }
 
         private ExecuteStatementResult GetExecuteResultNullStats()

--- a/Amazon.QLDB.Driver.Tests/RetryHandlerTests.cs
+++ b/Amazon.QLDB.Driver.Tests/RetryHandlerTests.cs
@@ -6,11 +6,9 @@ namespace Amazon.QLDB.Driver.Tests
     using System.Net;
     using Amazon.QLDBSession;
     using Amazon.QLDBSession.Model;
-    using Amazon.Runtime;
     using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
-    using Moq.Language;
 
     [TestClass]
     public class RetryHandlerTests
@@ -64,6 +62,7 @@ namespace Amazon.QLDB.Driver.Tests
             var defaultPolicy = Driver.RetryPolicy.Builder().Build();
             var customerPolicy = Driver.RetryPolicy.Builder().WithMaxRetries(10).Build();
 
+            var cee = new RetriableException("txnId11111", true, new CapacityExceededException("qldb"));
             var occ = new RetriableException("txnId11111", true, new OccConflictException("qldb", new BadRequestException("oops")));
             var occFailedAbort = new RetriableException("txnId11111", false, new OccConflictException("qldb", new BadRequestException("oops")));
             var txnExpiry = new RetriableException("txnid1111111", false, new InvalidSessionException("Transaction 324weqr2314 has expired"));
@@ -95,6 +94,9 @@ namespace Amazon.QLDB.Driver.Tests
                 // Retry OCC exceed limit.
                 new object[] { defaultPolicy, new Exception[] { occ, ise, http500, ise, occ }, typeof(OccConflictException), null,
                     Times.Exactly(5), Times.Exactly(2), Times.Never(), Times.Exactly(4) },
+                // Retry CapacityExceededException exceed limit.
+                new object[] { defaultPolicy, new Exception[] { cee, cee, cee, cee, cee }, typeof(CapacityExceededException), null,
+                    Times.Exactly(5), Times.Never(), Times.Never(), Times.Exactly(4) },
                 // Retry OCC with abort txn failures.
                 new object[] { defaultPolicy, new Exception[] { occFailedAbort, occ, occFailedAbort }, null, null,
                     Times.Exactly(4), Times.Never(), Times.Exactly(2), Times.Exactly(3) },

--- a/Amazon.QLDB.Driver.Tests/RetryHandlerTests.cs
+++ b/Amazon.QLDB.Driver.Tests/RetryHandlerTests.cs
@@ -6,6 +6,7 @@ namespace Amazon.QLDB.Driver.Tests
     using System.Net;
     using Amazon.QLDBSession;
     using Amazon.QLDBSession.Model;
+    using Amazon.Runtime;
     using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -62,7 +63,7 @@ namespace Amazon.QLDB.Driver.Tests
             var defaultPolicy = Driver.RetryPolicy.Builder().Build();
             var customerPolicy = Driver.RetryPolicy.Builder().WithMaxRetries(10).Build();
 
-            var cee = new RetriableException("txnId11111", true, new CapacityExceededException("qldb"));
+            var cee = new RetriableException("txnId11111", true, new CapacityExceededException("qldb", ErrorType.Receiver, "errorCode", "requestId", HttpStatusCode.ServiceUnavailable));
             var occ = new RetriableException("txnId11111", true, new OccConflictException("qldb", new BadRequestException("oops")));
             var occFailedAbort = new RetriableException("txnId11111", false, new OccConflictException("qldb", new BadRequestException("oops")));
             var txnExpiry = new RetriableException("txnid1111111", false, new InvalidSessionException("Transaction 324weqr2314 has expired"));

--- a/Amazon.QLDB.Driver.Tests/SessionPoolTests.cs
+++ b/Amazon.QLDB.Driver.Tests/SessionPoolTests.cs
@@ -15,6 +15,8 @@ namespace Amazon.QLDB.Driver.Tests
 {
     using System;
     using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Amazon.QLDBSession.Model;
     using Amazon.Runtime;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -27,16 +29,16 @@ namespace Amazon.QLDB.Driver.Tests
         [TestMethod]
         public void Constructor_CreateSessionPool_NewSessionPoolCreated()
         {
-            Assert.IsNotNull(new SessionPool(() => { return new Mock<Session>(null, null, null, null, null).Object; }, 
+            Assert.IsNotNull(new SessionPool(() => Task.FromResult(new Mock<Session>(null, null, null, null, null).Object),
                 new Mock<IRetryHandler>().Object, 1, NullLogger.Instance));
         }
 
         [TestMethod]
         public void GetSession_GetSessionFromPool_NewSessionReturned()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null).Object;
-            mockCreator.Setup(x => x()).Returns(mockSession);
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession);
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
             var returnedSession = pool.GetSession();
@@ -46,89 +48,89 @@ namespace Amazon.QLDB.Driver.Tests
         }
 
         [TestMethod]
-        public void GetSession_GetSessionFromPool_ExpectedSessionReturned()
+        public async Task GetSession_GetSessionFromPool_ExpectedSessionReturned()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var session = new Session(null, null, null, "testSessionId", null);
-            mockCreator.Setup(x => x()).Returns(session);
+            mockCreator.Setup(x => x()).ReturnsAsync(session);
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
-            var returnedSession = pool.GetSession();
+            var returnedSession = await pool.GetSession();
 
             Assert.AreEqual(session.SessionId, returnedSession.GetSessionId());
         }
 
         [TestMethod]
-        public void GetSession_GetTwoSessionsFromPoolOfOne_TimeoutOnSecondGet()
+        public async Task GetSession_GetTwoSessionsFromPoolOfOne_TimeoutOnSecondGet()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null).Object;
-            mockCreator.Setup(x => x()).Returns(mockSession);
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession);
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
             var returnedSession = pool.GetSession();
-            Assert.ThrowsException<QldbDriverException>(() => pool.GetSession());
+            await Assert.ThrowsExceptionAsync<QldbDriverException>(() => pool.GetSession());
 
             Assert.IsNotNull(returnedSession);
             mockCreator.Verify(x => x(), Times.Exactly(1));
         }
 
         [TestMethod]
-        public void GetSession_GetTwoSessionsFromPoolOfOneAfterFirstOneDisposed_NoThrowOnSecondGet()
+        public async Task GetSession_GetTwoSessionsFromPoolOfOneAfterFirstOneDisposed_NoThrowOnSecondGet()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null);
-            mockCreator.Setup(x => x()).Returns(mockSession.Object);
-            mockSession.Setup(x => x.StartTransaction()).Returns(new StartTransactionResult
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession.Object);
+            mockSession.Setup(x => x.StartTransaction(It.IsAny<CancellationToken>())).ReturnsAsync(new StartTransactionResult
             {
                 TransactionId = "testTransactionIdddddd"
             });
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
-            var returnedSession = pool.GetSession();
+            var returnedSession = await pool.GetSession();
             returnedSession.Release();
-            var nextSession = pool.GetSession();
+            var nextSession = await pool.GetSession();
             Assert.IsNotNull(nextSession);
 
-            nextSession.StartTransaction();
+            await nextSession.StartTransaction();
             mockCreator.Verify(x => x(), Times.Exactly(1));
         }
 
         [TestMethod]
-        public void GetSession_FailedToCreateSession_ThrowTheOriginalException()
+        public async Task GetSession_FailedToCreateSession_ThrowTheOriginalException()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var exception = new AmazonServiceException("test");
-            mockCreator.Setup(x => x()).Throws(exception);
+            mockCreator.Setup(x => x()).ThrowsAsync(exception);
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
 
-            Assert.ThrowsException<AmazonServiceException>(() => pool.GetSession());
+            await Assert.ThrowsExceptionAsync<AmazonServiceException>(() => pool.GetSession());
         }
 
         [TestMethod]
-        public void GetSession_DisposeSession_ShouldNotEndSession()
+        public async Task GetSession_DisposeSession_ShouldNotEndSession()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null);
-            mockCreator.Setup(x => x()).Returns(mockSession.Object);
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession.Object);
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
 
-            var returnedSession = pool.GetSession();
+            var returnedSession = await pool.GetSession();
 
             returnedSession.Release();
 
-            mockSession.Verify(s => s.End(), Times.Exactly(0));
+            mockSession.Verify(s => s.End(It.IsAny<CancellationToken>()), Times.Exactly(0));
         }
 
         [TestMethod]
-        public void Execute_NoException_ReturnFunctionValue()
+        public async Task Execute_NoException_ReturnFunctionValue()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null);
-            mockCreator.Setup(x => x()).Returns(mockSession.Object);
-            var retry = new Mock<Action<int>>();
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession.Object);
+            var retry = new Mock<Func<int, Task>>();
 
             var sendCommandResponseStart = new StartTransactionResult
             {
@@ -143,30 +145,30 @@ namespace Amazon.QLDB.Driver.Tests
                 TransactionId = "testTransactionIdddddd"
             };
 
-            mockSession.Setup(x => x.StartTransaction())
-                .Returns(sendCommandResponseStart);
-            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>()))
-                .Returns(sendCommandResponseCommit);
+            mockSession.Setup(x => x.StartTransaction(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseStart);
+            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseCommit);
 
-            var mockFunction = new Mock<Func<TransactionExecutor, int>>();
-            mockFunction.Setup(f => f.Invoke(It.IsAny<TransactionExecutor>())).Returns(1);
+            var mockFunction = new Mock<Func<TransactionExecutor, Task<int>>>();
+            mockFunction.Setup(f => f.Invoke(It.IsAny<TransactionExecutor>())).ReturnsAsync(1);
             var mockRetry = new Mock<Action<int>>();
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
 
-            pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object);
+            await pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object);
 
             mockCreator.Verify(x => x(), Times.Once);
             retry.Verify(r => r.Invoke(It.IsAny<int>()), Times.Never);
         }
 
         [TestMethod]
-        public void Execute_HaveOCCExceptionsWithinRetryLimit_Succeeded()
+        public async Task Execute_HaveOCCExceptionsWithinRetryLimit_Succeeded()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null);
-            mockCreator.Setup(x => x()).Returns(mockSession.Object);
-            var retry = new Mock<Action<int>>();
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession.Object);
+            var retry = new Mock<Func<int, Task>>();
 
             var sendCommandResponseStart = new StartTransactionResult
             {
@@ -181,22 +183,22 @@ namespace Amazon.QLDB.Driver.Tests
                 TransactionId = "testTransactionIdddddd"
             };
 
-            mockSession.Setup(x => x.StartTransaction())
-                .Returns(sendCommandResponseStart);
-            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>()))
-                .Returns(sendCommandResponseCommit);
+            mockSession.Setup(x => x.StartTransaction(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseStart);
+            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseCommit);
 
-            var mockFunction = new Mock<Func<TransactionExecutor, int>>();
+            var mockFunction = new Mock<Func<TransactionExecutor, Task<int>>>();
             mockFunction.SetupSequence(f => f.Invoke(It.IsAny<TransactionExecutor>()))
-                .Throws(new OccConflictException("occ"))
-                .Throws(new OccConflictException("occ"))
-                .Throws(new OccConflictException("occ"))
-                .Returns(1);
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ReturnsAsync(1);
             var mockRetry = new Mock<Action<int>>();
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
 
-            pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object);
+            await pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object);
 
             mockCreator.Verify(x => x(), Times.Once);
             retry.Verify(r => r.Invoke(It.IsAny<int>()), Times.Exactly(3));
@@ -204,12 +206,12 @@ namespace Amazon.QLDB.Driver.Tests
         }
 
         [TestMethod]
-        public void Execute_HaveOCCExceptionsAndAbortFailuresWithinRetryLimit_Succeeded()
+        public async Task Execute_HaveOCCExceptionsAndAbortFailuresWithinRetryLimit_Succeeded()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null);
-            mockCreator.Setup(x => x()).Returns(mockSession.Object);
-            var retry = new Mock<Action<int>>();
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession.Object);
+            var retry = new Mock<Func<int, Task>>();
 
             var sendCommandResponseStart = new StartTransactionResult
             {
@@ -227,28 +229,31 @@ namespace Amazon.QLDB.Driver.Tests
             var abortResponse = new AbortTransactionResult { };
             var serviceException = new AmazonServiceException();
 
-            mockSession.Setup(x => x.StartTransaction())
-                .Returns(sendCommandResponseStart);
-            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>()))
-                .Returns(sendCommandResponseCommit);
-            mockSession.SetupSequence(x => x.AbortTransaction()).Throws(serviceException).Returns(abortResponse).Throws(serviceException);
+            mockSession.Setup(x => x.StartTransaction(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseStart);
+            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseCommit);
+            mockSession.SetupSequence(x => x.AbortTransaction(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(serviceException)
+                .ReturnsAsync(abortResponse)
+                .ThrowsAsync(serviceException);
 
-            var mockFunction = new Mock<Func<TransactionExecutor, int>>();
+            var mockFunction = new Mock<Func<TransactionExecutor, Task<int>>>();
             mockFunction.SetupSequence(f => f.Invoke(It.IsAny<TransactionExecutor>()))
-                .Throws(new OccConflictException("occ"))
-                .Throws(new OccConflictException("occ"))
-                .Throws(new OccConflictException("occ"))
-                .Returns(1);
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ReturnsAsync(1);
             var mockRetry = new Mock<Action<int>>();
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 2, NullLogger.Instance);
 
-            var session1 = pool.GetSession();
-            var session2 = pool.GetSession();
+            var session1 = await pool.GetSession();
+            var session2 = await pool.GetSession();
             session1.Release();
             session2.Release();
 
-            pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object);
+            await pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object);
 
             mockCreator.Verify(x => x(), Times.Exactly(2));
             retry.Verify(r => r.Invoke(It.IsAny<int>()), Times.Exactly(3));
@@ -256,12 +261,12 @@ namespace Amazon.QLDB.Driver.Tests
         }
 
         [TestMethod]
-        public void Execute_HaveOCCExceptionsAboveRetryLimit_ThrowOCC()
+        public async Task Execute_HaveOCCExceptionsAboveRetryLimit_ThrowOCC()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null);
-            mockCreator.Setup(x => x()).Returns(mockSession.Object);
-            var retry = new Mock<Action<int>>();
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession.Object);
+            var retry = new Mock<Func<int, Task>>();
 
             var sendCommandResponseStart = new StartTransactionResult
             {
@@ -276,35 +281,35 @@ namespace Amazon.QLDB.Driver.Tests
                 TransactionId = "testTransactionIdddddd"
             };
 
-            mockSession.Setup(x => x.StartTransaction())
-                .Returns(sendCommandResponseStart);
-            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>()))
-                .Returns(sendCommandResponseCommit);
+            mockSession.Setup(x => x.StartTransaction(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseStart);
+            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseCommit);
 
-            var mockFunction = new Mock<Func<TransactionExecutor, int>>();
+            var mockFunction = new Mock<Func<TransactionExecutor, Task<int>>>();
             mockFunction.SetupSequence(f => f.Invoke(It.IsAny<TransactionExecutor>()))
-                .Throws(new OccConflictException("occ"))
-                .Throws(new OccConflictException("occ"))
-                .Throws(new OccConflictException("occ"))
-                .Throws(new OccConflictException("occ"))
-                .Throws(new OccConflictException("occ"));
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ThrowsAsync(new OccConflictException("occ"))
+                .ThrowsAsync(new OccConflictException("occ"));
             var mockRetry = new Mock<Action<int>>();
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 1, NullLogger.Instance);
 
-            Assert.ThrowsException<OccConflictException>(() => pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object));
+            await Assert.ThrowsExceptionAsync<OccConflictException>(() => pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object));
 
             mockCreator.Verify(x => x(), Times.Once);
             retry.Verify(r => r.Invoke(It.IsAny<int>()), Times.Exactly(4));
         }
 
         [TestMethod]
-        public void Execute_HaveISE_Succeeded()
+        public async Task Execute_HaveISE_Succeeded()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession = new Mock<Session>(null, null, null, null, null);
-            mockCreator.Setup(x => x()).Returns(mockSession.Object);
-            var retry = new Mock<Action<int>>();
+            mockCreator.Setup(x => x()).ReturnsAsync(mockSession.Object);
+            var retry = new Mock<Func<int, Task>>();
 
             var sendCommandResponseStart = new StartTransactionResult
             {
@@ -319,28 +324,28 @@ namespace Amazon.QLDB.Driver.Tests
                 TransactionId = "testTransactionIdddddd"
             };
 
-            mockSession.Setup(x => x.StartTransaction())
-                .Returns(sendCommandResponseStart);
-            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>()))
-                .Returns(sendCommandResponseCommit);
+            mockSession.Setup(x => x.StartTransaction(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseStart);
+            mockSession.Setup(x => x.CommitTransaction(It.IsAny<string>(), It.IsAny<MemoryStream>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sendCommandResponseCommit);
 
-            var mockFunction = new Mock<Func<TransactionExecutor, int>>();
+            var mockFunction = new Mock<Func<TransactionExecutor, Task<int>>>();
             mockFunction.SetupSequence(f => f.Invoke(It.IsAny<TransactionExecutor>()))
-                .Throws(new InvalidSessionException("invalid"))
-                .Throws(new InvalidSessionException("invalid"))
-                .Throws(new InvalidSessionException("invalid"))
-                .Throws(new InvalidSessionException("invalid"))
-                .Returns(1);
+                .ThrowsAsync(new InvalidSessionException("invalid"))
+                .ThrowsAsync(new InvalidSessionException("invalid"))
+                .ThrowsAsync(new InvalidSessionException("invalid"))
+                .ThrowsAsync(new InvalidSessionException("invalid"))
+                .ReturnsAsync(1);
             var mockRetry = new Mock<Action<int>>();
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 2, NullLogger.Instance);
 
-            var session1 = pool.GetSession();
-            var session2 = pool.GetSession();
+            var session1 = await pool.GetSession();
+            var session2 = await pool.GetSession();
             session1.Release();
             session2.Release();
 
-            pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object);
+            await pool.Execute(mockFunction.Object, Driver.RetryPolicy.Builder().Build(), retry.Object);
 
             mockCreator.Verify(x => x(), Times.Exactly(6));
             retry.Verify(r => r.Invoke(It.IsAny<int>()), Times.Exactly(4));
@@ -348,24 +353,24 @@ namespace Amazon.QLDB.Driver.Tests
         }
 
         [TestMethod]
-        public void Dispose_DisposeSessionPool_DestroyAllSessions()
+        public async Task Dispose_DisposeSessionPool_DestroyAllSessions()
         {
-            var mockCreator = new Mock<Func<Session>>();
+            var mockCreator = new Mock<Func<Task<Session>>>();
             var mockSession1 = new Mock<Session>(null, null, null, null, null);
             var mockSession2 = new Mock<Session>(null, null, null, null, null);
-            mockCreator.SetupSequence(x => x()).Returns(mockSession1.Object).Returns(mockSession2.Object);
+            mockCreator.SetupSequence(x => x()).ReturnsAsync(mockSession1.Object).ReturnsAsync(mockSession2.Object);
 
             var pool = new SessionPool(mockCreator.Object, QldbDriverBuilder.CreateDefaultRetryHandler(NullLogger.Instance), 2, NullLogger.Instance);
 
-            var session1 = pool.GetSession();
-            var session2 = pool.GetSession();
+            var session1 = await pool.GetSession();
+            var session2 = await pool.GetSession();
             session1.Release();
             session2.Release();
 
-            pool.Dispose();
+            await pool.DisposeAsync();
 
-            mockSession1.Verify(s => s.End(), Times.Exactly(1));
-            mockSession2.Verify(s => s.End(), Times.Exactly(1));
+            mockSession1.Verify(s => s.End(It.IsAny<CancellationToken>()), Times.Exactly(1));
+            mockSession2.Verify(s => s.End(It.IsAny<CancellationToken>()), Times.Exactly(1));
         }
     }
 }

--- a/Amazon.QLDB.Driver.Tests/SessionTests.cs
+++ b/Amazon.QLDB.Driver.Tests/SessionTests.cs
@@ -34,7 +34,7 @@ namespace Amazon.QLDB.Driver.Tests
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
-        public static void Setup(TestContext context)
+        public static async Task Setup(TestContext context)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
             var testStartSessionResponse = new SendCommandResponse
@@ -50,7 +50,7 @@ namespace Amazon.QLDB.Driver.Tests
             };
             SetResponse(testStartSessionResponse);
 
-            session = Session.StartSession("testLedgerName", mockClient.Object, NullLogger.Instance);
+            session = await Session.StartSession("testLedgerName", mockClient.Object, NullLogger.Instance);
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace Amazon.QLDB.Driver.Tests
         }
 
         [TestMethod]
-        public void TestAbortTransactionReturnsResponse()
+        public async Task TestAbortTransactionReturnsResponse()
         {
             var testAbortTransactionResult = new AbortTransactionResult();
             var testAbortTransactionResponse = new SendCommandResponse
@@ -70,11 +70,11 @@ namespace Amazon.QLDB.Driver.Tests
             };
             SetResponse(testAbortTransactionResponse);
 
-            Assert.AreEqual(testAbortTransactionResult, session.AbortTransaction());
+            Assert.AreEqual(testAbortTransactionResult, await session.AbortTransaction());
         }
 
         [TestMethod]
-        public void TestEndSessionReturnsResponse()
+        public async Task TestEndSessionReturnsResponse()
         {
             var testEndSessionResult = new EndSessionResult();
             var testEndSessionResponse = new SendCommandResponse
@@ -83,20 +83,20 @@ namespace Amazon.QLDB.Driver.Tests
             };
             SetResponse(testEndSessionResponse);
 
-            Assert.AreEqual(testEndSessionResult, session.EndSession());
+            Assert.AreEqual(testEndSessionResult, await session.EndSession());
         }
 
         [TestMethod]
-        public void TestEndSendsEndSessionAndIgnoresExceptions()
+        public async Task TestEndSendsEndSessionAndIgnoresExceptions()
         {
             mockClient.Setup(x => x.SendCommandAsync(It.IsAny<SendCommandRequest>(), It.IsAny<CancellationToken>()))
                 .Throws(new AmazonServiceException());
 
-            session.End();
+            await session.End();
         }
 
         [TestMethod]
-        public void TestCommitTransactionReturnsResponse()
+        public async Task TestCommitTransactionReturnsResponse()
         {
             var testCommitTransactionResult = new CommitTransactionResult
             {
@@ -109,11 +109,11 @@ namespace Amazon.QLDB.Driver.Tests
             };
             SetResponse(testCommitTransactionResponse);
 
-            Assert.AreEqual(testCommitTransactionResult, session.CommitTransaction("txnId", new MemoryStream()));
+            Assert.AreEqual(testCommitTransactionResult, await session.CommitTransaction("txnId", new MemoryStream()));
         }
 
         [TestMethod]
-        public void TestExecuteStatementReturnsResponse()
+        public async Task TestExecuteStatementReturnsResponse()
         {
             var testExecuteStatementResult = new ExecuteStatementResult
             {
@@ -132,15 +132,15 @@ namespace Amazon.QLDB.Driver.Tests
                 valueFactory.NewString("param2")
             };
 
-            var executeResultParams = session.ExecuteStatement("txnId", "statement", parameters);
+            var executeResultParams = await session.ExecuteStatement("txnId", "statement", parameters);
             Assert.AreEqual(testExecuteStatementResult, executeResultParams);
 
-            var executeResultEmptyParams = session.ExecuteStatement("txnId", "statement", new List<IIonValue>());
+            var executeResultEmptyParams = await session.ExecuteStatement("txnId", "statement", new List<IIonValue>());
             Assert.AreEqual(testExecuteStatementResult, executeResultEmptyParams);
         }
 
         [TestMethod]
-        public void TestFetchPageReturnsResponse()
+        public async Task TestFetchPageReturnsResponse()
         {
             var testFetchPageResult = new FetchPageResult
             {
@@ -152,11 +152,11 @@ namespace Amazon.QLDB.Driver.Tests
             };
             SetResponse(testFetchPageResponse);
 
-            Assert.AreEqual(testFetchPageResult, session.FetchPage("txnId", "nextPageToken"));
+            Assert.AreEqual(testFetchPageResult, await session.FetchPage("txnId", "nextPageToken"));
         }
 
         [TestMethod]
-        public void TestStartTransactionReturnsResponse()
+        public async Task TestStartTransactionReturnsResponse()
         {
             var testStartTransactionResult = new StartTransactionResult
             {
@@ -168,13 +168,13 @@ namespace Amazon.QLDB.Driver.Tests
             };
             SetResponse(testStartTransactionResponse);
 
-            Assert.AreEqual(testStartTransactionResult, session.StartTransaction());
+            Assert.AreEqual(testStartTransactionResult, await session.StartTransaction());
         }
 
         private static void SetResponse(SendCommandResponse response)
         {
             mockClient.Setup(x => x.SendCommandAsync(It.IsAny<SendCommandRequest>(), It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(response));
+                    .ReturnsAsync(response);
         }
     }
 }

--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -23,6 +23,7 @@
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
     <ReleaseVersion>1.1.1</ReleaseVersion>
     <PackageIcon>product-icon_AWS_Quantum_125_squid-ink.png</PackageIcon>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -34,6 +35,7 @@
     <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.2" />
     <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
     <PackageReference Include="Amazon.IonHashDotnet" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Amazon.QLDB.Driver</RootNamespace>
     <Company>Amazon.com, Inc.</Company>
     <Authors>Amazon Web Services</Authors>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageId>Amazon.QLDB.Driver</PackageId>
     <Description>A .NET implementation of the Amazon QLDB driver that can be used to programmatically access and interact with data in Amazon QLDB ledgers.</Description>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -21,7 +21,7 @@
     <PackageTags>amazon api aws database driver ledger qldb quantum</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
-    <ReleaseVersion>1.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1.1</ReleaseVersion>
     <PackageIcon>product-icon_AWS_Quantum_125_squid-ink.png</PackageIcon>
   </PropertyGroup>
 
@@ -31,10 +31,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.2" />
     <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
     <PackageReference Include="Amazon.IonHashDotnet" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Amazon.QLDB.Driver/client/IOUsage.cs
+++ b/Amazon.QLDB.Driver/client/IOUsage.cs
@@ -18,18 +18,18 @@ namespace Amazon.QLDB.Driver
     /// </summary>
     public readonly struct IOUsage
     {
-        internal IOUsage(long? readIOs, long? writeIOs)
+        internal IOUsage(long readIOs, long writeIOs)
         {
             this.ReadIOs = readIOs;
             this.WriteIOs = writeIOs;
         }
 
-        public long? ReadIOs
+        public long ReadIOs
         {
             get;
         }
 
-        internal long? WriteIOs
+        internal long WriteIOs
         {
             get;
         }

--- a/Amazon.QLDB.Driver/client/TimingInformation.cs
+++ b/Amazon.QLDB.Driver/client/TimingInformation.cs
@@ -18,12 +18,12 @@ namespace Amazon.QLDB.Driver
     /// </summary>
     public readonly struct TimingInformation
     {
-        internal TimingInformation(long? processingTimeMilliseconds)
+        internal TimingInformation(long processingTimeMilliseconds)
         {
             this.ProcessingTimeMilliseconds = processingTimeMilliseconds;
         }
 
-        public long? ProcessingTimeMilliseconds
+        public long ProcessingTimeMilliseconds
         {
             get;
         }

--- a/Amazon.QLDB.Driver/driver/IQldbDriver.cs
+++ b/Amazon.QLDB.Driver/driver/IQldbDriver.cs
@@ -15,24 +15,44 @@ namespace Amazon.QLDB.Driver
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Amazon.Runtime;
 
     /// <summary>
     /// Interface for the QLDB driver.
     /// </summary>
-    public interface IQldbDriver : IDisposable
+    public interface IQldbDriver : IAsyncDisposable
     {
         /// <summary>
         /// Execute the Executor lambda against QLDB within a transaction where no result is expected.
         /// </summary>
         ///
         /// <param name="action">The Executor lambda with no return value representing the block of code to be executed within the transaction.
-        /// This cannot have any side effects as it may be invoked multiple times.</param>
+        /// This cannot have any side effects as it may be invoked multiple times. The operation can be cancelled.</param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         ///
         /// <exception cref="TransactionAbortedException">Thrown if the Executor lambda calls <see cref="TransactionExecutor.Abort"/>.</exception>
         /// <exception cref="QldbDriverException">Thrown when called on a disposed instance.</exception>
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        void Execute(Action<TransactionExecutor> action);
+        Task Execute(Func<TransactionExecutor, CancellationToken, Task> action, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Execute the Executor lambda against QLDB within a transaction where no result is expected.
+        /// </summary>
+        ///
+        /// <param name="action">The Executor lambda with no return value representing the block of code to be executed within the transaction.
+        /// This cannot have any side effects as it may be invoked multiple times.</param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        ///
+        /// <exception cref="TransactionAbortedException">Thrown if the Executor lambda calls <see cref="TransactionExecutor.Abort"/>.</exception>
+        /// <exception cref="QldbDriverException">Thrown when called on a disposed instance.</exception>
+        /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
+        Task Execute(Func<TransactionExecutor, Task> action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Execute the Executor lambda against QLDB within a transaction where no result is expected.
@@ -54,14 +74,34 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <param name="action">The Executor lambda with no return value representing the block of code to be executed within the transaction.
-        /// This cannot have any side effects as it may be invoked multiple times.</param>
+        /// This cannot have any side effects as it may be invoked multiple times. The operation can be cancelled.</param>
         /// <param name="retryPolicy">A <see cref="RetryPolicy"/> that overrides the RetryPolicy set when creating the driver. The given retry policy
         /// will be used when retrying the transaction.</param>
-        ///
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// 
         /// <exception cref="TransactionAbortedException">Thrown if the Executor lambda calls <see cref="TransactionExecutor.Abort"/>.</exception>
         /// <exception cref="QldbDriverException">Thrown when called on a disposed instance.</exception>
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        void Execute(Action<TransactionExecutor> action, RetryPolicy retryPolicy);
+        Task Execute(Func<TransactionExecutor, CancellationToken, Task> action, RetryPolicy retryPolicy, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Execute the Executor lambda against QLDB within a transaction where no result is expected.
+        /// </summary>
+        ///
+        /// <param name="action">The Executor lambda with no return value representing the block of code to be executed within the transaction.
+        /// This cannot have any side effects as it may be invoked multiple times.</param>
+        /// <param name="retryPolicy">A <see cref="RetryPolicy"/> that overrides the RetryPolicy set when creating the driver. The given retry policy
+        /// will be used when retrying the transaction.</param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        /// 
+        /// <exception cref="TransactionAbortedException">Thrown if the Executor lambda calls <see cref="TransactionExecutor.Abort"/>.</exception>
+        /// <exception cref="QldbDriverException">Thrown when called on a disposed instance.</exception>
+        /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
+        Task Execute(Func<TransactionExecutor, Task> action, RetryPolicy retryPolicy, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Execute the Executor lambda against QLDB and retrieve the result within a transaction.
@@ -69,8 +109,11 @@ namespace Amazon.QLDB.Driver
         ///
         /// <param name="func">The Executor lambda representing the block of code to be executed within the transaction. This cannot have any
         /// side effects as it may be invoked multiple times, and the result cannot be trusted until the
-        /// transaction is committed.</param>
+        /// transaction is committed. The operation can be cancelled.</param>
         /// <typeparam name="T">The return type.</typeparam>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         ///
         /// <returns>The return value of executing the executor. Note that if you directly return a <see cref="IResult"/>, this will
         /// be automatically buffered in memory before the implicit commit to allow reading, as the commit will close
@@ -81,7 +124,30 @@ namespace Amazon.QLDB.Driver
         /// <exception cref="TransactionAbortedException">Thrown if the Executor lambda calls <see cref="TransactionExecutor.Abort"/>.</exception>
         /// <exception cref="QldbDriverException">Thrown when called on a disposed instance.</exception>
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        T Execute<T>(Func<TransactionExecutor, T> func);
+        Task<T> Execute<T>(Func<TransactionExecutor, CancellationToken, Task<T>> func, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Execute the Executor lambda against QLDB and retrieve the result within a transaction.
+        /// </summary>
+        ///
+        /// <param name="func">The Executor lambda representing the block of code to be executed within the transaction. This cannot have any
+        /// side effects as it may be invoked multiple times, and the result cannot be trusted until the
+        /// transaction is committed.</param>
+        /// <typeparam name="T">The return type.</typeparam>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        ///
+        /// <returns>The return value of executing the executor. Note that if you directly return a <see cref="IResult"/>, this will
+        /// be automatically buffered in memory before the implicit commit to allow reading, as the commit will close
+        /// any open results. Any other <see cref="IResult"/> instances created within the executor block will be
+        /// invalidated, including if the return value is an object which nests said <see cref="IResult"/> instances within it.
+        /// </returns>
+        ///
+        /// <exception cref="TransactionAbortedException">Thrown if the Executor lambda calls <see cref="TransactionExecutor.Abort"/>.</exception>
+        /// <exception cref="QldbDriverException">Thrown when called on a disposed instance.</exception>
+        /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
+        Task<T> Execute<T>(Func<TransactionExecutor, Task<T>> func, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Execute the Executor lambda against QLDB and retrieve the result within a transaction.
@@ -112,10 +178,13 @@ namespace Amazon.QLDB.Driver
         ///
         /// <param name="func">The Executor lambda representing the block of code to be executed within the transaction. This cannot have any
         /// side effects as it may be invoked multiple times, and the result cannot be trusted until the
-        /// transaction is committed.</param>
+        /// transaction is committed. The operation can be cancelled.</param>
         /// <param name="retryPolicy">A <see cref="RetryPolicy"/> that overrides the RetryPolicy set when creating the driver. The given retry policy
         /// will be used when retrying the transaction.</param>
         /// <typeparam name="T">The return type.</typeparam>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         ///
         /// <returns>The return value of executing the executor. Note that if you directly return a <see cref="IResult"/>, this will
         /// be automatically buffered in memory before the implicit commit to allow reading, as the commit will close
@@ -126,13 +195,43 @@ namespace Amazon.QLDB.Driver
         /// <exception cref="TransactionAbortedException">Thrown if the Executor lambda calls <see cref="TransactionExecutor.Abort"/>.</exception>
         /// <exception cref="QldbDriverException">Thrown when called on a disposed instance.</exception>
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        T Execute<T>(Func<TransactionExecutor, T> func, RetryPolicy retryPolicy);
+        Task<T> Execute<T>(Func<TransactionExecutor, CancellationToken, Task<T>> func, RetryPolicy retryPolicy, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Execute the Executor lambda against QLDB and retrieve the result within a transaction.
+        /// </summary>
+        ///
+        /// <param name="func">The Executor lambda representing the block of code to be executed within the transaction. This cannot have any
+        /// side effects as it may be invoked multiple times, and the result cannot be trusted until the
+        /// transaction is committed.</param>
+        /// <param name="retryPolicy">A <see cref="RetryPolicy"/> that overrides the RetryPolicy set when creating the driver. The given retry policy
+        /// will be used when retrying the transaction.</param>
+        /// <typeparam name="T">The return type.</typeparam>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        ///
+        /// <returns>The return value of executing the executor. Note that if you directly return a <see cref="IResult"/>, this will
+        /// be automatically buffered in memory before the implicit commit to allow reading, as the commit will close
+        /// any open results. Any other <see cref="IResult"/> instances created within the executor block will be
+        /// invalidated, including if the return value is an object which nests said <see cref="IResult"/> instances within it.
+        /// </returns>
+        ///
+        /// <exception cref="TransactionAbortedException">Thrown if the Executor lambda calls <see cref="TransactionExecutor.Abort"/>.</exception>
+        /// <exception cref="QldbDriverException">Thrown when called on a disposed instance.</exception>
+        /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
+        Task<T> Execute<T>(Func<TransactionExecutor, Task<T>> func, RetryPolicy retryPolicy, CancellationToken cancellationToken = default);
+
 
         /// <summary>
         /// Retrieve the table names that are available within the ledger.
         /// </summary>
         ///
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        ///
         /// <returns>The Enumerable over the table names in the ledger.</returns>
-        IEnumerable<string> ListTableNames();
+        Task<IEnumerable<string>> ListTableNames(CancellationToken cancellationToken = default);
     }
 }

--- a/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
+++ b/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
@@ -188,7 +188,7 @@
         private static void SetUserAgent(object sender, RequestEventArgs eventArgs)
         {
             const string UserAgentHeader = "User-Agent";
-            const string Version = "1.1.0";
+            const string Version = "1.1.1";
 
             if (!(eventArgs is WebServiceRequestEventArgs args) || !args.Headers.ContainsKey(UserAgentHeader))
             {

--- a/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
+++ b/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
@@ -133,7 +133,7 @@
         }
 
         /// <summary>
-        /// Enable loggging driver retries at the WARN level.
+        /// Enable logging driver retries at the WARN level.
         /// </summary>
         /// <returns>This builder object.</returns>
         public QldbDriverBuilder WithRetryLogging()

--- a/Amazon.QLDB.Driver/executable/IExecutable.cs
+++ b/Amazon.QLDB.Driver/executable/IExecutable.cs
@@ -14,6 +14,8 @@
 namespace Amazon.QLDB.Driver
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Amazon.IonDotnet.Tree;
     using Amazon.Runtime;
 
@@ -27,10 +29,11 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <param name="statement">The PartiQL statement to be executed against QLDB.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         ///
         /// <returns>Result from executed statement.</returns>
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        IResult Execute(string statement);
+        Task<IResult> Execute(string statement, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Execute the statement using the specified parameters against QLDB and retrieve the result.
@@ -38,20 +41,22 @@ namespace Amazon.QLDB.Driver
         ///
         /// <param name="statement">The PartiQL statement to be executed against QLDB.</param>
         /// <param name="parameters">Parameters to execute.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         ///
         /// <returns>Result from executed statement.</returns>
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        IResult Execute(string statement, List<IIonValue> parameters);
+        Task<IResult> Execute(string statement, List<IIonValue> parameters, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Execute the statement using the specified parameters against QLDB and retrieve the result.
         /// </summary>
         ///
         /// <param name="statement">The PartiQL statement to be executed against QLDB.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         /// <param name="parameters">Parameters to execute.</param>
         ///
         /// <returns>Result from executed statement.</returns>
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        IResult Execute(string statement, params IIonValue[] parameters);
+        Task<IResult> Execute(string statement, CancellationToken cancellationToken = default, params IIonValue[] parameters);
     }
 }

--- a/Amazon.QLDB.Driver/result/BufferedResult.cs
+++ b/Amazon.QLDB.Driver/result/BufferedResult.cs
@@ -25,8 +25,8 @@ namespace Amazon.QLDB.Driver
     public class BufferedResult : IResult
     {
         private readonly List<IIonValue> values;
-        private readonly IOUsage consumedIOs;
-        private readonly TimingInformation timingInformation;
+        private readonly IOUsage? consumedIOs;
+        private readonly TimingInformation? timingInformation;
 
         /// <summary>
         /// Prevents a default instance of the <see cref="BufferedResult"/> class from being created.
@@ -35,7 +35,7 @@ namespace Amazon.QLDB.Driver
         /// <param name="values">Buffer values.</param>
         /// <param name="consumedIOs">IOUsage statistics.</param>
         /// <param name="timingInformation">TimingInformation statistics.</param>
-        private BufferedResult(List<IIonValue> values, IOUsage consumedIOs, TimingInformation timingInformation)
+        private BufferedResult(List<IIonValue> values, IOUsage? consumedIOs, TimingInformation? timingInformation)
         {
             this.values = values;
             this.consumedIOs = consumedIOs;
@@ -83,7 +83,7 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current IOUsage statistics.</returns>
-        public IOUsage GetConsumedIOs()
+        public IOUsage? GetConsumedIOs()
         {
             return this.consumedIOs;
         }
@@ -93,7 +93,7 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current TimingInformation statistics.</returns>
-        public TimingInformation GetTimingInformation()
+        public TimingInformation? GetTimingInformation()
         {
             return this.timingInformation;
         }

--- a/Amazon.QLDB.Driver/result/IResult.cs
+++ b/Amazon.QLDB.Driver/result/IResult.cs
@@ -27,13 +27,13 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current IOUsage statistics.</returns>
-        IOUsage GetConsumedIOs();
+        IOUsage? GetConsumedIOs();
 
         /// <summary>
         /// Gets the current query statistics for server-side processing time. The statistics are stateful.
         /// </summary>
         ///
         /// <returns>The current TimingInformation statistics.</returns>
-        TimingInformation GetTimingInformation();
+        TimingInformation? GetTimingInformation();
     }
 }

--- a/Amazon.QLDB.Driver/result/IResult.cs
+++ b/Amazon.QLDB.Driver/result/IResult.cs
@@ -18,9 +18,9 @@ namespace Amazon.QLDB.Driver
 
     /// <summary>
     /// Interface for the result of executing a statement in QLDB.
-    /// Implements IEnumerable to allow iteration over Ion values within the result.
+    /// Implements IAsyncEnumerable&lgt;IIonValue&gt; to allow asynchronous iteration over Ion values within the result.
     /// </summary>
-    public interface IResult : IEnumerable<IIonValue>
+    public interface IResult : IAsyncEnumerable<IIonValue>
     {
         /// <summary>
         /// Gets the current query statistics for the number of read IO requests. The statistics are stateful.

--- a/Amazon.QLDB.Driver/result/Result.cs
+++ b/Amazon.QLDB.Driver/result/Result.cs
@@ -68,7 +68,7 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current IOUsage statistics.</returns>
-        public IOUsage GetConsumedIOs()
+        public IOUsage? GetConsumedIOs()
         {
             return this.ionEnumerator.GetConsumedIOs();
         }
@@ -78,7 +78,7 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current TimingInformation statistics.</returns>
-        public TimingInformation GetTimingInformation()
+        public TimingInformation? GetTimingInformation()
         {
             return this.ionEnumerator.GetTimingInformation();
         }
@@ -182,9 +182,14 @@ namespace Amazon.QLDB.Driver
             /// </summary>
             ///
             /// <returns>The current IOUsage statistics.</returns>
-            internal IOUsage GetConsumedIOs()
+            internal IOUsage? GetConsumedIOs()
             {
-                return new IOUsage(this.readIOs, this.writeIOs);
+                if (this.readIOs != null || this.writeIOs != null)
+                {
+                    return new IOUsage(this.readIOs.GetValueOrDefault(), this.writeIOs.GetValueOrDefault());
+                }
+
+                return null;
             }
 
             /// <summary>
@@ -192,9 +197,14 @@ namespace Amazon.QLDB.Driver
             /// </summary>
             ///
             /// <returns>The current TimingInformation statistics.</returns>
-            internal TimingInformation GetTimingInformation()
+            internal TimingInformation? GetTimingInformation()
             {
-                return new TimingInformation(this.processingTimeMilliseconds);
+                if (this.processingTimeMilliseconds != null)
+                {
+                    return new TimingInformation(this.processingTimeMilliseconds.Value);
+                }
+
+                return null;
             }
 
             /// <summary>

--- a/Amazon.QLDB.Driver/retry/IRetryHandler.cs
+++ b/Amazon.QLDB.Driver/retry/IRetryHandler.cs
@@ -14,6 +14,8 @@
 namespace Amazon.QLDB.Driver
 {
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Interface of Retry Handler.
@@ -24,12 +26,32 @@ namespace Amazon.QLDB.Driver
         /// Execute a retriable function.
         /// </summary>
         /// <typeparam name="T">The return type of the executed function.</typeparam>
+        /// <param name="func">The function to be executed and retried if needed. The operation can be cancelled.</param>
+        /// <param name="retryPolicy">The retry policy.</param>
+        /// <param name="newSessionAction">The action to move to a new session. The operation can be cancelled.</param>
+        /// <param name="nextSessionAction">The action to get the next session. The operation can be cancelled.</param>
+        /// <param name="retryAction">The custom retry action. The operation can be cancelled.</param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        ///
+        /// <returns>The return value of the executed function.</returns>
+        Task<T> RetriableExecute<T>(Func<CancellationToken, Task<T>> func, RetryPolicy retryPolicy, Func<CancellationToken, Task> newSessionAction, Func<CancellationToken, Task> nextSessionAction, Func<int, CancellationToken, Task> retryAction, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Execute a retriable function.
+        /// </summary>
+        /// <typeparam name="T">The return type of the executed function.</typeparam>
         /// <param name="func">The function to be executed and retried if needed.</param>
         /// <param name="retryPolicy">The retry policy.</param>
         /// <param name="newSessionAction">The action to move to a new session.</param>
         /// <param name="nextSessionAction">The action to get the next session.</param>
         /// <param name="retryAction">The custom retry action.</param>
+        /// <param name="cancellationToken">
+        ///     A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
+        ///
         /// <returns>The return value of the executed function.</returns>
-        T RetriableExecute<T>(Func<T> func, RetryPolicy retryPolicy, Action newSessionAction, Action nextSessionAction, Action<int> retryAction);
+        Task<T> RetriableExecute<T>(Func<Task<T>> func, RetryPolicy retryPolicy, Func<Task> newSessionAction, Func<Task> nextSessionAction, Func<int, Task> retryAction, CancellationToken cancellationToken = default);
     }
 }

--- a/Amazon.QLDB.Driver/retry/RetryHandler.cs
+++ b/Amazon.QLDB.Driver/retry/RetryHandler.cs
@@ -103,7 +103,7 @@ namespace Amazon.QLDB.Driver
 
         private static string TryGetTransactionId(Exception ex)
         {
-            return ex is QldbTransactionException exception ? exception.TransactionId : string.Empty;
+            return ex is QldbTransactionException exception ? exception.TransactionId : "None";
         }
     }
 }

--- a/Amazon.QLDB.Driver/session/QldbSession.cs
+++ b/Amazon.QLDB.Driver/session/QldbSession.cs
@@ -134,10 +134,6 @@ namespace Amazon.QLDB.Driver
             {
                 throw new RetriableException(transactionId, occ);
             }
-            catch (CapacityExceededException cee)
-            {
-                throw new RetriableException(transaction.Id, this.TryAbort(transaction), cee);
-            }
             catch (AmazonServiceException ase)
             {
                 if (ase.StatusCode == HttpStatusCode.InternalServerError ||

--- a/Amazon.QLDB.Driver/session/QldbSession.cs
+++ b/Amazon.QLDB.Driver/session/QldbSession.cs
@@ -134,6 +134,10 @@ namespace Amazon.QLDB.Driver
             {
                 throw new RetriableException(transactionId, occ);
             }
+            catch (CapacityExceededException cee)
+            {
+                throw new RetriableException(transaction.Id, this.TryAbort(transaction), cee);
+            }
             catch (AmazonServiceException ase)
             {
                 if (ase.StatusCode == HttpStatusCode.InternalServerError ||

--- a/Amazon.QLDB.Driver/transaction/ITransaction.cs
+++ b/Amazon.QLDB.Driver/transaction/ITransaction.cs
@@ -14,6 +14,8 @@
 namespace Amazon.QLDB.Driver
 {
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Amazon.QLDBSession.Model;
     using Amazon.Runtime;
 
@@ -33,7 +35,7 @@ namespace Amazon.QLDB.Driver
     ///
     /// <para>Child Result objects will be closed when the transaction is aborted or committed.</para>
     /// </summary>
-    internal interface ITransaction : IDisposable, IExecutable
+    internal interface ITransaction : IAsyncDisposable, IExecutable
     {
         string Id { get; }
 
@@ -41,16 +43,23 @@ namespace Amazon.QLDB.Driver
         /// Abort the transaction and roll back any changes. No-op if closed.
         /// Any open <see cref="IResult"/> created by the transaction will be invalidated.
         /// </summary>
-        void Abort();
+        ///
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        ///
+        /// <returns>A task representing the asynchronous abort operation.</returns>
+        Task Abort(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Commit the transaction. Any open <see cref="IResult"/> created by the transaction will be invalidated.
         /// </summary>
         ///
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        ///
         /// <exception cref="InvalidOperationException">Thrown when Hash returned from QLDB is not equal.</exception>
         /// <exception cref="OccConflictException">Thrown if an OCC conflict has been detected within the transaction.</exception>
         /// <exception cref="AmazonServiceException">Thrown when there is an error committing this transaction against QLDB.</exception>
         /// <exception cref="QldbDriverException">Thrown when this transaction has been disposed.</exception>
-        void Commit();
+        /// <returns>A task representing the asynchronous commit operation.</returns>
+        Task Commit(CancellationToken cancellationToken = default);
     }
 }

--- a/Amazon.QLDB.Driver/transaction/TransactionExecutor.cs
+++ b/Amazon.QLDB.Driver/transaction/TransactionExecutor.cs
@@ -14,6 +14,8 @@
 namespace Amazon.QLDB.Driver
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Amazon.IonDotnet.Tree;
     using Amazon.Runtime;
 
@@ -38,11 +40,14 @@ namespace Amazon.QLDB.Driver
         /// <summary>
         /// Abort the transaction and roll back any changes.
         /// </summary>
-        public void Abort()
+        ///
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        ///
+        public async Task Abort(CancellationToken cancellationToken = default)
         {
             try
             {
-                this.transaction.Abort();
+                await this.transaction.Abort(cancellationToken);
                 throw new TransactionAbortedException(this.transaction.Id, true);
             }
             catch (AmazonServiceException ase)
@@ -56,13 +61,46 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <param name="statement">The PartiQL statement to be executed against QLDB.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         ///
         /// <returns>Result from executed statement.</returns>
         ///
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        public IResult Execute(string statement)
+        public Task<IResult> Execute(string statement, CancellationToken cancellationToken = default)
         {
-            return this.transaction.Execute(statement);
+            return this.transaction.Execute(statement, cancellationToken);
+        }
+
+        /// <summary>
+        /// Execute the statement using the specified parameters against QLDB and retrieve the result.
+        /// </summary>
+        ///
+        /// <param name="statement">The PartiQL statement to be executed against QLDB.</param>
+        /// <param name="parameters">Parameters to execute.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        ///
+        /// <returns>Result from executed statement.</returns>
+        ///
+        /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
+        public Task<IResult> Execute(string statement, List<IIonValue> parameters, CancellationToken cancellationToken = default)
+        {
+            return this.transaction.Execute(statement, parameters, cancellationToken);
+        }
+
+        /// <summary>
+        /// Execute the statement using the specified parameters against QLDB and retrieve the result.
+        /// </summary>
+        ///
+        /// <param name="statement">The PartiQL statement to be executed against QLDB.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        /// <param name="parameters">Parameters to execute.</param>
+        ///
+        /// <returns>Result from executed statement.</returns>
+        ///
+        /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
+        public Task<IResult> Execute(string statement, CancellationToken cancellationToken = default, params IIonValue[] parameters)
+        {
+            return this.transaction.Execute(statement, cancellationToken, parameters);
         }
 
         /// <summary>
@@ -75,24 +113,9 @@ namespace Amazon.QLDB.Driver
         /// <returns>Result from executed statement.</returns>
         ///
         /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        public IResult Execute(string statement, List<IIonValue> parameters)
+        public Task<IResult> Execute(string statement, params IIonValue[] parameters)
         {
-            return this.transaction.Execute(statement, parameters);
-        }
-
-        /// <summary>
-        /// Execute the statement using the specified parameters against QLDB and retrieve the result.
-        /// </summary>
-        ///
-        /// <param name="statement">The PartiQL statement to be executed against QLDB.</param>
-        /// <param name="parameters">Parameters to execute.</param>
-        ///
-        /// <returns>Result from executed statement.</returns>
-        ///
-        /// <exception cref="AmazonServiceException">Thrown when there is an error executing against QLDB.</exception>
-        public IResult Execute(string statement, params IIonValue[] parameters)
-        {
-            return this.transaction.Execute(statement, parameters);
+            return this.transaction.Execute(statement, default, parameters);
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Release v1.1.1
 
 * Update the minimum version of the driver's logging dependency to 2.0.0
-* Update the minimum version of the driver's SDK dependency to 3.5.1
 * Update the minimum version of the driver's AWS SDK dependency to 3.5.2
 * Fixed a bug where it was throwing NullReferenceException after session expiry.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Release v1.1.1
+
+* Update the minimum version of the driver's logging dependency to 2.0.0
+* Update the minimum version of the driver's SDK dependency to 3.5.1
+* Update the minimum version of the driver's AWS SDK dependency to 3.5.2
+* Fixed a bug where it was throwing NullReferenceException after session expiry.
+
 ## Release v1.1.0
 
 v1.1 adds support for obtaining basic server-side statistics on individual statement executions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ v1.1 adds support for obtaining basic server-side statistics on individual state
 ### :hammer_and_wrench: Improvements
 
 * Added `IOUsage` and `TimingInformation` struct types containing information on server-side statistics
-  * IOUsage contains `long? ReadIOs`
-  * TimingInformation contains `long? ProcessingTimeMilliseconds`
-* Added `IOUsage GetConsumedIOs()` and `TimingInformation GetTimingInformation()` to the `IResult` interface
+  * IOUsage contains `long ReadIOs`
+  * TimingInformation contains `long ProcessingTimeMilliseconds`
+* Added `IOUsage? GetConsumedIOs()` and `TimingInformation? GetTimingInformation()` to the `IResult` interface
   * IOUsage and TimingInformation are stateful, meaning the statistics returned by the method reflect the state at the time of method execution
 
 ## Release v1.0.1


### PR DESCRIPTION
Closes #28

*Description of changes:*

Since this library is doing IO with HTTP requests to the AWS QLDB service, then by using synchronous code we will get some threads in a waiting/blocked state, instead of freeing them. The consequence is the web server's performance will drop, as it will handle fewer requests due to the lack of available threads.


The changes in this PR are:
- unblocks and awaits the SendCommandAsync; the consequence is any method that uses will be also async
- unblocks and awaits FetchPage; iterating through the results does not block (uses the C# 8.0 asynchronous iterators)
- unblocks and awaits Dispose; disposing does not block
- uses asynchronous delays instead Thread.Sleep and also the SemaphoreSlim's async api

All these are breaking changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
