### PR TITLE
Bump Amazon.IonHasDtonet to 1.0.1

### DIFF
--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.QLDBSession" Version="3.3.100.147" />
     <PackageReference Include="Amazon.IonDotnet" Version="1.0.0" />
-    <PackageReference Include="Amazon.IonHashDotnet" Version="1.0.0" />
+    <PackageReference Include="Amazon.IonHashDotnet" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Bump Amazon.IonHasDtonet to 1.0.1 so it closes Issue #31

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
