### PR TITLE
Fix failing build on MacOS

### DIFF
--- a/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.Mac.csproj
+++ b/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.Mac.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <ReleaseVersion>1.0.1</ReleaseVersion>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NLog" Version="4.7.4" />
+    <PackageReference Include="AWSSDK.QLDB" Version="3.5.0.9" />
+    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Amazon.QLDB.Driver\Amazon.QLDB.Driver.csproj" />
+  </ItemGroup>
+</Project>

--- a/Amazon.QLDB.Driver.Mac.sln
+++ b/Amazon.QLDB.Driver.Mac.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29509.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.QLDB.Driver", "Amazon.QLDB.Driver\Amazon.QLDB.Driver.csproj", "{C46C7A89-46ED-4D2B-BA83-AE9EE03EDBEC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.QLDB.Driver.Tests", "Amazon.QLDB.Driver.Tests\Amazon.QLDB.Driver.Tests.Mac.csproj", "{DBAC6479-92C8-444F-ADA9-9B7938B9DC1A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.QLDB.Driver.IntegrationTests", "Amazon.QLDB.Driver.IntegrationTests\Amazon.QLDB.Driver.IntegrationTests.Mac.csproj", "{43A3FB70-E041-4FED-8335-0D8DDBF59F45}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C46C7A89-46ED-4D2B-BA83-AE9EE03EDBEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C46C7A89-46ED-4D2B-BA83-AE9EE03EDBEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C46C7A89-46ED-4D2B-BA83-AE9EE03EDBEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C46C7A89-46ED-4D2B-BA83-AE9EE03EDBEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBAC6479-92C8-444F-ADA9-9B7938B9DC1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBAC6479-92C8-444F-ADA9-9B7938B9DC1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBAC6479-92C8-444F-ADA9-9B7938B9DC1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBAC6479-92C8-444F-ADA9-9B7938B9DC1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43A3FB70-E041-4FED-8335-0D8DDBF59F45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43A3FB70-E041-4FED-8335-0D8DDBF59F45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43A3FB70-E041-4FED-8335-0D8DDBF59F45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43A3FB70-E041-4FED-8335-0D8DDBF59F45}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {932685C8-D694-41D2-8854-B1BF081812B6}
+	EndGlobalSection
+EndGlobal

--- a/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.Mac.csproj
+++ b/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.Mac.csproj
@@ -5,7 +5,6 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
-    <ReleaseVersion>1.0.1</ReleaseVersion>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 

--- a/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.Mac.csproj
+++ b/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.Mac.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
+    <ReleaseVersion>1.0.1</ReleaseVersion>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Amazon.QLDB.Driver\Amazon.QLDB.Driver.csproj" />
+  </ItemGroup>
+</Project>

--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -56,6 +56,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>$(AssemblyName).Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100516caa6311db961cb07702d63876c5b8cbd661557cd18bde9fb966bb30a4442abb27a4a5aca5af15c97b77f3f8f683eb1ca32cd7e8d1edcbbb1a62fe215001d507c2437f052b29540b7a11edbdc7dfe12de00c37f9e70c7e85a04541858ca46bb2581099780121ee8041732b7214ec9b5c483ef13c1db6d5f86a71fcc014dcaf</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Amazon.QLDB.Driver.Tests.Mac, PublicKey=0024000004800000940000000602000000240000525341310004000001000100516caa6311db961cb07702d63876c5b8cbd661557cd18bde9fb966bb30a4442abb27a4a5aca5af15c97b77f3f8f683eb1ca32cd7e8d1edcbbb1a62fe215001d507c2437f052b29540b7a11edbdc7dfe12de00c37f9e70c7e85a04541858ca46bb2581099780121ee8041732b7214ec9b5c483ef13c1db6d5f86a71fcc014dcaf</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the driver does not build successfully on Mac OS. This is happening on Mac OS Catalina (10.15.7)
Error: 
```
Project Amazon.QLDB.Driver is not compatible with net48 (.NETFramework,Version=v4.8). Project Amazon.QLDB.Driver supports: netcoreapp2.1 (.NETCoreApp,Version=v2.1)
```

I have created duplicate files for the sln and Test/Integration csproj files and appended them with `mac`. I removed the `net48` target version in them.

To run successfully on Mac:
1. Open `Amazon.QLDB.Driver.Mac.sln` in Visual Studio 2019 for Mac
2. Build project (build fails with error:
```
/usr/local/share/dotnet/sdk/5.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(241,5): error NETSDK1005: Assets file '/Users/byronlin/projects/github-customer-fork/amazon-qldb-driver-dotnet/Amazon.QLDB.Driver/obj/project.assets.json' doesn't have a target for 'netstandard2.0'. Ensure that restore has run and that you have included 'netstandard2.0' in the TargetFrameworks for your project.
```

3. Run on command line: `dotnet restore Amazon.QLDB.Driver.Mac.sln `
4. Build project again (will succeed)

For Windows users, they would just open `Amazon.QLDB.Driver.sln` in Visual studio for Windows (I've tested this).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
