### PR TITLE
Return null for execution stats when they are null

### DIFF
--- a/Amazon.QLDB.Driver.IntegrationTests/StatementExecutionTests.cs
+++ b/Amazon.QLDB.Driver.IntegrationTests/StatementExecutionTests.cs
@@ -838,8 +838,8 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
                     Assert.IsNotNull(ioUsage);
                     Assert.IsNotNull(timingInfo);
-                    Assert.IsTrue(ioUsage.ReadIOs > 0);
-                    Assert.IsTrue(timingInfo.ProcessingTimeMilliseconds > 0);
+                    Assert.IsTrue(ioUsage?.ReadIOs > 0);
+                    Assert.IsTrue(timingInfo?.ProcessingTimeMilliseconds > 0);
                 }
             });
 
@@ -854,8 +854,8 @@ namespace Amazon.QLDB.Driver.IntegrationTests
 
             Assert.IsNotNull(ioUsage);
             Assert.IsNotNull(timingInfo);
-            Assert.AreEqual(1092, ioUsage.ReadIOs);
-            Assert.IsTrue(timingInfo.ProcessingTimeMilliseconds > 0);
+            Assert.AreEqual(1092, ioUsage?.ReadIOs);
+            Assert.IsTrue(timingInfo?.ProcessingTimeMilliseconds > 0);
         }
 
         public static IEnumerable<object[]> CreateIonValues()

--- a/Amazon.QLDB.Driver.Tests/ResultTests.cs
+++ b/Amazon.QLDB.Driver.Tests/ResultTests.cs
@@ -165,9 +165,8 @@ namespace Amazon.QLDB.Driver.Tests
 
             var io = result.GetConsumedIOs();
             var timing = result.GetTimingInformation();
-            Assert.IsNull(io.ReadIOs);
-            Assert.IsNull(io.WriteIOs);
-            Assert.IsNull(timing.ProcessingTimeMilliseconds);
+            Assert.IsNull(io);
+            Assert.IsNull(timing);
 
             var results = result.GetEnumerator();
             while (results.MoveNext())
@@ -177,9 +176,8 @@ namespace Amazon.QLDB.Driver.Tests
 
             io = result.GetConsumedIOs();
             timing = result.GetTimingInformation();
-            Assert.IsNull(io.ReadIOs);
-            Assert.IsNull(io.WriteIOs);
-            Assert.IsNull(timing.ProcessingTimeMilliseconds);
+            Assert.IsNull(io);
+            Assert.IsNull(timing);
         }
 
         [TestMethod]
@@ -195,9 +193,8 @@ namespace Amazon.QLDB.Driver.Tests
 
             var io = result.GetConsumedIOs();
             var timing = result.GetTimingInformation();
-            Assert.IsNull(io.ReadIOs);
-            Assert.IsNull(io.WriteIOs);
-            Assert.IsNull(timing.ProcessingTimeMilliseconds);
+            Assert.IsNull(io);
+            Assert.IsNull(timing);
 
             var results = result.GetEnumerator();
             while (results.MoveNext())
@@ -207,9 +204,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             io = result.GetConsumedIOs();
             timing = result.GetTimingInformation();
-            Assert.AreEqual(fetchReads, io.ReadIOs);
-            Assert.AreEqual(fetchWrites, io.WriteIOs);
-            Assert.AreEqual(fetchTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(fetchReads, io?.ReadIOs);
+            Assert.AreEqual(fetchWrites, io?.WriteIOs);
+            Assert.AreEqual(fetchTime, timing?.ProcessingTimeMilliseconds);
         }
 
         [TestMethod]
@@ -225,9 +222,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             var io = result.GetConsumedIOs();
             var timing = result.GetTimingInformation();
-            Assert.AreEqual(executeReads, io.ReadIOs);
-            Assert.AreEqual(executeWrites, io.WriteIOs);
-            Assert.AreEqual(executeTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(executeReads, io?.ReadIOs);
+            Assert.AreEqual(executeWrites, io?.WriteIOs);
+            Assert.AreEqual(executeTime, timing?.ProcessingTimeMilliseconds);
 
             var results = result.GetEnumerator();
             while (results.MoveNext())
@@ -237,9 +234,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             io = result.GetConsumedIOs();
             timing = result.GetTimingInformation();
-            Assert.AreEqual(executeReads, io.ReadIOs);
-            Assert.AreEqual(executeWrites, io.WriteIOs);
-            Assert.AreEqual(executeTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(executeReads, io?.ReadIOs);
+            Assert.AreEqual(executeWrites, io?.WriteIOs);
+            Assert.AreEqual(executeTime, timing?.ProcessingTimeMilliseconds);
         }
 
         [TestMethod]
@@ -255,9 +252,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             var io = result.GetConsumedIOs();
             var timing = result.GetTimingInformation();
-            Assert.AreEqual(executeReads, io.ReadIOs);
-            Assert.AreEqual(executeWrites, io.WriteIOs);
-            Assert.AreEqual(executeTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(executeReads, io?.ReadIOs);
+            Assert.AreEqual(executeWrites, io?.WriteIOs);
+            Assert.AreEqual(executeTime, timing?.ProcessingTimeMilliseconds);
 
             var results = result.GetEnumerator();
             while (results.MoveNext())
@@ -267,9 +264,9 @@ namespace Amazon.QLDB.Driver.Tests
 
             io = result.GetConsumedIOs();
             timing = result.GetTimingInformation();
-            Assert.AreEqual(executeReads + fetchReads, io.ReadIOs);
-            Assert.AreEqual(executeWrites + fetchWrites, io.WriteIOs);
-            Assert.AreEqual(executeTime + fetchTime, timing.ProcessingTimeMilliseconds);
+            Assert.AreEqual(executeReads + fetchReads, io?.ReadIOs);
+            Assert.AreEqual(executeWrites + fetchWrites, io?.WriteIOs);
+            Assert.AreEqual(executeTime + fetchTime, timing?.ProcessingTimeMilliseconds);
         }
 
         private ExecuteStatementResult GetExecuteResultNullStats()

--- a/Amazon.QLDB.Driver/client/IOUsage.cs
+++ b/Amazon.QLDB.Driver/client/IOUsage.cs
@@ -18,18 +18,18 @@ namespace Amazon.QLDB.Driver
     /// </summary>
     public readonly struct IOUsage
     {
-        internal IOUsage(long? readIOs, long? writeIOs)
+        internal IOUsage(long readIOs, long writeIOs)
         {
             this.ReadIOs = readIOs;
             this.WriteIOs = writeIOs;
         }
 
-        public long? ReadIOs
+        public long ReadIOs
         {
             get;
         }
 
-        internal long? WriteIOs
+        internal long WriteIOs
         {
             get;
         }

--- a/Amazon.QLDB.Driver/client/TimingInformation.cs
+++ b/Amazon.QLDB.Driver/client/TimingInformation.cs
@@ -18,12 +18,12 @@ namespace Amazon.QLDB.Driver
     /// </summary>
     public readonly struct TimingInformation
     {
-        internal TimingInformation(long? processingTimeMilliseconds)
+        internal TimingInformation(long processingTimeMilliseconds)
         {
             this.ProcessingTimeMilliseconds = processingTimeMilliseconds;
         }
 
-        public long? ProcessingTimeMilliseconds
+        public long ProcessingTimeMilliseconds
         {
             get;
         }

--- a/Amazon.QLDB.Driver/result/BufferedResult.cs
+++ b/Amazon.QLDB.Driver/result/BufferedResult.cs
@@ -25,8 +25,8 @@ namespace Amazon.QLDB.Driver
     public class BufferedResult : IResult
     {
         private readonly List<IIonValue> values;
-        private readonly IOUsage consumedIOs;
-        private readonly TimingInformation timingInformation;
+        private readonly IOUsage? consumedIOs;
+        private readonly TimingInformation? timingInformation;
 
         /// <summary>
         /// Prevents a default instance of the <see cref="BufferedResult"/> class from being created.
@@ -35,7 +35,7 @@ namespace Amazon.QLDB.Driver
         /// <param name="values">Buffer values.</param>
         /// <param name="consumedIOs">IOUsage statistics.</param>
         /// <param name="timingInformation">TimingInformation statistics.</param>
-        private BufferedResult(List<IIonValue> values, IOUsage consumedIOs, TimingInformation timingInformation)
+        private BufferedResult(List<IIonValue> values, IOUsage? consumedIOs, TimingInformation? timingInformation)
         {
             this.values = values;
             this.consumedIOs = consumedIOs;
@@ -83,7 +83,7 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current IOUsage statistics.</returns>
-        public IOUsage GetConsumedIOs()
+        public IOUsage? GetConsumedIOs()
         {
             return this.consumedIOs;
         }
@@ -93,7 +93,7 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current TimingInformation statistics.</returns>
-        public TimingInformation GetTimingInformation()
+        public TimingInformation? GetTimingInformation()
         {
             return this.timingInformation;
         }

--- a/Amazon.QLDB.Driver/result/IResult.cs
+++ b/Amazon.QLDB.Driver/result/IResult.cs
@@ -27,13 +27,13 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current IOUsage statistics.</returns>
-        IOUsage GetConsumedIOs();
+        IOUsage? GetConsumedIOs();
 
         /// <summary>
         /// Gets the current query statistics for server-side processing time. The statistics are stateful.
         /// </summary>
         ///
         /// <returns>The current TimingInformation statistics.</returns>
-        TimingInformation GetTimingInformation();
+        TimingInformation? GetTimingInformation();
     }
 }

--- a/Amazon.QLDB.Driver/result/Result.cs
+++ b/Amazon.QLDB.Driver/result/Result.cs
@@ -68,7 +68,7 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current IOUsage statistics.</returns>
-        public IOUsage GetConsumedIOs()
+        public IOUsage? GetConsumedIOs()
         {
             return this.ionEnumerator.GetConsumedIOs();
         }
@@ -78,7 +78,7 @@ namespace Amazon.QLDB.Driver
         /// </summary>
         ///
         /// <returns>The current TimingInformation statistics.</returns>
-        public TimingInformation GetTimingInformation()
+        public TimingInformation? GetTimingInformation()
         {
             return this.ionEnumerator.GetTimingInformation();
         }
@@ -182,9 +182,14 @@ namespace Amazon.QLDB.Driver
             /// </summary>
             ///
             /// <returns>The current IOUsage statistics.</returns>
-            internal IOUsage GetConsumedIOs()
+            internal IOUsage? GetConsumedIOs()
             {
-                return new IOUsage(this.readIOs, this.writeIOs);
+                if (this.readIOs != null || this.writeIOs != null)
+                {
+                    return new IOUsage(this.readIOs.GetValueOrDefault(), this.writeIOs.GetValueOrDefault());
+                }
+
+                return null;
             }
 
             /// <summary>
@@ -192,9 +197,14 @@ namespace Amazon.QLDB.Driver
             /// </summary>
             ///
             /// <returns>The current TimingInformation statistics.</returns>
-            internal TimingInformation GetTimingInformation()
+            internal TimingInformation? GetTimingInformation()
             {
-                return new TimingInformation(this.processingTimeMilliseconds);
+                if (this.processingTimeMilliseconds != null)
+                {
+                    return new TimingInformation(this.processingTimeMilliseconds.Value);
+                }
+
+                return null;
             }
 
             /// <summary>


### PR DESCRIPTION
*Description of changes:*
In case the server-side statistics are null, `Result` and `BufferedResult` are going to return null for `getConsumedIOs()` and `GetTimingInformation()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
