### PR TITLE
Set logging dependency min version to 2.0.0

### DIFF
--- a/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
+++ b/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="NLog" Version="4.7.6" />
     <PackageReference Include="AWSSDK.QLDB" Version="3.5.0.57" />
-    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
+++ b/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1.1</ReleaseVersion>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 

--- a/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.csproj
+++ b/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
-    <ReleaseVersion>1.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1.1</ReleaseVersion>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 

--- a/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
@@ -388,8 +388,9 @@ namespace Amazon.QLDB.Driver.Tests
             return new List<object[]>() {
                 new object[] { new InvalidSessionException("invalid session"), false },
                 new object[] { new OccConflictException("occ"), false },
+                new object[] { new CapacityExceededException("capacity exceeded"), false },
                 new object[] { new ArgumentException(), true },
-                new object[] { new QldbDriverException("generic"), true }
+                new object[] { new QldbDriverException("generic"), true },
             };
         }
     }

--- a/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
@@ -192,6 +192,9 @@ namespace Amazon.QLDB.Driver.Tests
         public static IEnumerable<object[]> CreateExceptionTestData()
         {
             return new List<object[]>() {
+                new object[] { new CapacityExceededException("Capacity Exceeded Exception"),
+                    typeof(RetriableException), typeof(CapacityExceededException),
+                    Times.Once()},
                 new object[] { new AmazonQLDBSessionException("", 0, "", "", HttpStatusCode.InternalServerError),
                     typeof(RetriableException), null,
                     Times.Once()},

--- a/Amazon.QLDB.Driver.Tests/RetryHandlerTests.cs
+++ b/Amazon.QLDB.Driver.Tests/RetryHandlerTests.cs
@@ -6,11 +6,9 @@ namespace Amazon.QLDB.Driver.Tests
     using System.Net;
     using Amazon.QLDBSession;
     using Amazon.QLDBSession.Model;
-    using Amazon.Runtime;
     using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
-    using Moq.Language;
 
     [TestClass]
     public class RetryHandlerTests
@@ -64,6 +62,7 @@ namespace Amazon.QLDB.Driver.Tests
             var defaultPolicy = Driver.RetryPolicy.Builder().Build();
             var customerPolicy = Driver.RetryPolicy.Builder().WithMaxRetries(10).Build();
 
+            var cee = new RetriableException("txnId11111", true, new CapacityExceededException("qldb"));
             var occ = new RetriableException("txnId11111", true, new OccConflictException("qldb", new BadRequestException("oops")));
             var occFailedAbort = new RetriableException("txnId11111", false, new OccConflictException("qldb", new BadRequestException("oops")));
             var txnExpiry = new RetriableException("txnid1111111", false, new InvalidSessionException("Transaction 324weqr2314 has expired"));
@@ -95,6 +94,9 @@ namespace Amazon.QLDB.Driver.Tests
                 // Retry OCC exceed limit.
                 new object[] { defaultPolicy, new Exception[] { occ, ise, http500, ise, occ }, typeof(OccConflictException), null,
                     Times.Exactly(5), Times.Exactly(2), Times.Never(), Times.Exactly(4) },
+                // Retry CapacityExceededException exceed limit.
+                new object[] { defaultPolicy, new Exception[] { cee, cee, cee, cee, cee }, typeof(CapacityExceededException), null,
+                    Times.Exactly(5), Times.Never(), Times.Never(), Times.Exactly(4) },
                 // Retry OCC with abort txn failures.
                 new object[] { defaultPolicy, new Exception[] { occFailedAbort, occ, occFailedAbort }, null, null,
                     Times.Exactly(4), Times.Never(), Times.Exactly(2), Times.Exactly(3) },

--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.1.4" />
     <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
     <PackageReference Include="Amazon.IonHashDotnet" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Amazon.QLDB.Driver</RootNamespace>
     <Company>Amazon.com, Inc.</Company>
     <Authors>Amazon Web Services</Authors>
-    <Version>1.1.1</Version>
+    <Version>1.1.0</Version>
     <PackageId>Amazon.QLDB.Driver</PackageId>
     <Description>A .NET implementation of the Amazon QLDB driver that can be used to programmatically access and interact with data in Amazon QLDB ledgers.</Description>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -21,7 +21,7 @@
     <PackageTags>amazon api aws database driver ledger qldb quantum</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
-    <ReleaseVersion>1.1.1</ReleaseVersion>
+    <ReleaseVersion>1.1.0</ReleaseVersion>
     <PackageIcon>product-icon_AWS_Quantum_125_squid-ink.png</PackageIcon>
   </PropertyGroup>
 
@@ -31,10 +31,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.1" />
+    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.2" />
     <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
     <PackageReference Include="Amazon.IonHashDotnet" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Amazon.QLDB.Driver</RootNamespace>
     <Company>Amazon.com, Inc.</Company>
     <Authors>Amazon Web Services</Authors>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageId>Amazon.QLDB.Driver</PackageId>
     <Description>A .NET implementation of the Amazon QLDB driver that can be used to programmatically access and interact with data in Amazon QLDB ledgers.</Description>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -21,7 +21,7 @@
     <PackageTags>amazon api aws database driver ledger qldb quantum</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
-    <ReleaseVersion>1.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1.1</ReleaseVersion>
     <PackageIcon>product-icon_AWS_Quantum_125_squid-ink.png</PackageIcon>
   </PropertyGroup>
 
@@ -34,7 +34,7 @@
     <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.2" />
     <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
     <PackageReference Include="Amazon.IonHashDotnet" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Amazon.QLDB.Driver</RootNamespace>
     <Company>Amazon.com, Inc.</Company>
     <Authors>Amazon Web Services</Authors>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageId>Amazon.QLDB.Driver</PackageId>
     <Description>A .NET implementation of the Amazon QLDB driver that can be used to programmatically access and interact with data in Amazon QLDB ledgers.</Description>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -21,7 +21,7 @@
     <PackageTags>amazon api aws database driver ledger qldb quantum</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
-    <ReleaseVersion>1.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1.1</ReleaseVersion>
     <PackageIcon>product-icon_AWS_Quantum_125_squid-ink.png</PackageIcon>
   </PropertyGroup>
 

--- a/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
+++ b/Amazon.QLDB.Driver/Amazon.QLDB.Driver.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.1" />
     <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
     <PackageReference Include="Amazon.IonHashDotnet" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />

--- a/Amazon.QLDB.Driver/session/QldbSession.cs
+++ b/Amazon.QLDB.Driver/session/QldbSession.cs
@@ -132,6 +132,10 @@ namespace Amazon.QLDB.Driver
             {
                 throw new RetriableException(transaction.Id, occ);
             }
+            catch (CapacityExceededException cee)
+            {
+                throw new RetriableException(transaction.Id, this.TryAbort(transaction), cee);
+            }
             catch (AmazonServiceException ase)
             {
                 if (ase.StatusCode == HttpStatusCode.InternalServerError ||

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update the minimum version of the driver's logging dependency to 2.0.0
 * Update the minimum version of the driver's SDK dependency to 3.5.1
+* Fixed a bug where it was throwing NullReferenceException after session expiry.
 
 ## Release v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release v1.1.1
 
 * Update the minimum version of the driver's logging dependency to 2.0.0
+* Update the minimum version of the drivers' SDK dependency to 3.5.1
 
 ## Release v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release v1.1.1
+
+* Update the minimum version of the driver's logging dependency to 2.0.0
+
 ## Release v1.1.0
 
 v1.1 adds support for obtaining basic server-side statistics on individual statement executions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update the minimum version of the driver's logging dependency to 2.0.0
 * Update the minimum version of the driver's SDK dependency to 3.5.1
 * Fixed a bug where it was throwing NullReferenceException after session expiry.
+* Bump the AWS SDK version to v3.5.2
 
 ## Release v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Release v1.1.1
 
 * Update the minimum version of the driver's logging dependency to 2.0.0
-* Update the minimum version of the drivers' SDK dependency to 3.5.1
+* Update the minimum version of the driver's SDK dependency to 3.5.1
 
 ## Release v1.1.0
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the driver csproj file has the logging dependency minimum version set to v5. This forces users to update to the .NET 5* set of Microsoft packages which is not a good experience and some users cannot update to v5.

The changes in this PR are to:
* Update the minimum version of the logging framework to v2.0.0 ([to match the minimum .NET core version supported by .NET standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard))
* For the Ion dependencies, we will specify the latest version so they get the newest features.
* Update minimum version of AWS SDK to [3.5.2](https://github.com/aws/aws-sdk-net/blob/master/SDK.CHANGELOG.md#351060-2021-02-09-1913-utc)(SDK containing CapacityExceededException exception)

Tested this successfully by:
1. Create .NET3.1 project
2. Add  v3.1.11 Microsoft.Extensions.DependencyInjection NuGet package
3. Add QLDB driver local NuGet package (with v2.0.0 min logging framework)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
