### PR TITLE
Fix null reference exception

### DIFF
--- a/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
@@ -27,7 +27,6 @@ namespace Amazon.QLDB.Driver.Tests
     using Amazon.QLDBSession;
     using Amazon.QLDBSession.Model;
     using Amazon.Runtime;
-    using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
     using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -74,7 +73,7 @@ namespace Amazon.QLDB.Driver.Tests
 
         [DataTestMethod]
         [DynamicData(nameof(CreateExecuteTestData), DynamicDataSourceType.Method)]
-        public void Exectue_CustomerTransactionTest(Func<TransactionExecutor, Object> transaction, Object expected, Type expectedExceptionType, Type innerExceptionType,
+        public void Execute_CustomerTransactionTest(Func<TransactionExecutor, Object> transaction, Object expected, Type expectedExceptionType, Type innerExceptionType,
             Times startTxnTimes, Times executeTimes, Times commitTimes, Times abortTimes, Times retryTimes)
         {
             mockSession.Setup(x => x.StartTransaction()).Returns(new StartTransactionResult
@@ -250,6 +249,26 @@ namespace Amazon.QLDB.Driver.Tests
         }
 
         [TestMethod]
+        [DynamicData(nameof(CreateExceptions), DynamicDataSourceType.Method)]
+        public void Execute_StartTransactionThrowExceptions(Exception exception)
+        {
+            mockSession.Setup(x => x.StartTransaction()).Throws(exception);
+
+            if (exception.GetType() == typeof(Exception) ||
+                (exception.GetType() == typeof(AmazonServiceException) && ((AmazonServiceException)exception).StatusCode != HttpStatusCode.InternalServerError && ((AmazonServiceException)exception).StatusCode != HttpStatusCode.ServiceUnavailable))
+            {
+                Assert.ThrowsException<QldbTransactionException>(
+                    () => qldbSession.Execute(
+                        (TransactionExecutor txn) => { txn.Execute("testStatement"); return true; }));
+
+            } else {
+                Assert.ThrowsException<RetriableException>(
+                    () => qldbSession.Execute(
+                        (TransactionExecutor txn) => { txn.Execute("testStatement"); return true; }));
+            }
+        }
+
+        [TestMethod]
         public void TestStartTransactionReturnsANewTransaction()
         {
             mockSession.Setup(x => x.StartTransaction()).Returns(new StartTransactionResult
@@ -266,6 +285,19 @@ namespace Amazon.QLDB.Driver.Tests
             public virtual void DisposeDelegate(QldbSession session)
             {
             }
+        }
+
+        public static IEnumerable<Object[]> CreateExceptions()
+        {
+            return new List<object[]>()
+            {
+                new object[] { new InvalidSessionException("message") },
+                new object[] { new OccConflictException("message") },
+                new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.InternalServerError) },
+                new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.ServiceUnavailable) },
+                new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.Conflict) },
+                new object[] { new Exception("message")},
+            };
         }
     }
 }

--- a/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
+++ b/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
@@ -133,7 +133,7 @@
         }
 
         /// <summary>
-        /// Enable loggging driver retries at the WARN level.
+        /// Enable logging driver retries at the WARN level.
         /// </summary>
         /// <returns>This builder object.</returns>
         public QldbDriverBuilder WithRetryLogging()

--- a/Amazon.QLDB.Driver/retry/RetryHandler.cs
+++ b/Amazon.QLDB.Driver/retry/RetryHandler.cs
@@ -103,7 +103,7 @@ namespace Amazon.QLDB.Driver
 
         private static string TryGetTransactionId(Exception ex)
         {
-            return ex is QldbTransactionException exception ? exception.TransactionId : string.Empty;
+            return ex is QldbTransactionException exception ? exception.TransactionId : "None";
         }
     }
 }

--- a/Amazon.QLDB.Driver/session/QldbSession.cs
+++ b/Amazon.QLDB.Driver/session/QldbSession.cs
@@ -111,9 +111,11 @@ namespace Amazon.QLDB.Driver
             ValidationUtils.AssertNotNull(func, "func");
 
             ITransaction transaction = null;
+            string transactionId = null;
             try
             {
                 transaction = this.StartTransaction();
+                transactionId = transaction.Id;
                 T returnedValue = func(new TransactionExecutor(transaction));
                 if (returnedValue is IResult)
                 {
@@ -126,21 +128,21 @@ namespace Amazon.QLDB.Driver
             catch (InvalidSessionException ise)
             {
                 this.isAlive = false;
-                throw new RetriableException(transaction.Id, false, ise);
+                throw new RetriableException(transactionId, false, ise);
             }
             catch (OccConflictException occ)
             {
-                throw new RetriableException(transaction.Id, occ);
+                throw new RetriableException(transactionId, occ);
             }
             catch (AmazonServiceException ase)
             {
                 if (ase.StatusCode == HttpStatusCode.InternalServerError ||
                     ase.StatusCode == HttpStatusCode.ServiceUnavailable)
                 {
-                    throw new RetriableException(transaction.Id, this.TryAbort(transaction), ase);
+                    throw new RetriableException(transactionId, this.TryAbort(transaction), ase);
                 }
 
-                throw new QldbTransactionException(transaction.Id, this.TryAbort(transaction), ase);
+                throw new QldbTransactionException(transactionId, this.TryAbort(transaction), ase);
             }
             catch (QldbTransactionException te)
             {
@@ -148,7 +150,7 @@ namespace Amazon.QLDB.Driver
             }
             catch (Exception e)
             {
-                throw new QldbTransactionException(transaction == null ? null : transaction.Id, this.TryAbort(transaction), e);
+                throw new QldbTransactionException(transactionId, this.TryAbort(transaction), e);
             }
         }
 

--- a/Amazon.QLDB.Driver/session/QldbSession.cs
+++ b/Amazon.QLDB.Driver/session/QldbSession.cs
@@ -111,7 +111,7 @@ namespace Amazon.QLDB.Driver
             ValidationUtils.AssertNotNull(func, "func");
 
             ITransaction transaction = null;
-            string transactionId = null;
+            string transactionId = "None";
             try
             {
                 transaction = this.StartTransaction();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the `QldbSession.Execute()` convenience function, `StartTransaction()` can throw an `InvalidSessionException` due to session expiry in 15 minutes. This will be caught but when we create the `RetriableException`, we are passing in the `transaction.Id`. This will throw a `NullReferenceException` because `transaction` object is `null` (since `StartTransaction()`) was not successful.

The fix is to set default value of transaction ID as `'None'` and update it when `StartTransaction()` is successful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
