### PR TITLE
Update CapacityExceededException handling

### DIFF
--- a/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
@@ -16,6 +16,7 @@ namespace Amazon.QLDB.Driver.Tests
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Amazon.QLDBSession;
@@ -388,7 +389,7 @@ namespace Amazon.QLDB.Driver.Tests
             return new List<object[]>() {
                 new object[] { new InvalidSessionException("invalid session"), false },
                 new object[] { new OccConflictException("occ"), false },
-                new object[] { new CapacityExceededException("capacity exceeded"), false },
+                new object[] { new CapacityExceededException("capacity exceeded", ErrorType.Receiver, "errorCode", "requestId", HttpStatusCode.ServiceUnavailable), false },
                 new object[] { new ArgumentException(), true },
                 new object[] { new QldbDriverException("generic"), true },
             };

--- a/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbSessionTests.cs
@@ -191,7 +191,7 @@ namespace Amazon.QLDB.Driver.Tests
         public static IEnumerable<object[]> CreateExceptionTestData()
         {
             return new List<object[]>() {
-                new object[] { new CapacityExceededException("Capacity Exceeded Exception"),
+                new object[] { new CapacityExceededException("Capacity Exceeded Exception", ErrorType.Receiver, "errorCode", "requestId", HttpStatusCode.ServiceUnavailable),
                     typeof(RetriableException), typeof(CapacityExceededException),
                     Times.Once()},
                 new object[] { new AmazonQLDBSessionException("", 0, "", "", HttpStatusCode.InternalServerError),
@@ -300,6 +300,7 @@ namespace Amazon.QLDB.Driver.Tests
                 new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.ServiceUnavailable) },
                 new object[] { new AmazonServiceException("message", new Exception(), HttpStatusCode.Conflict) },
                 new object[] { new Exception("message")},
+                new object[] { new CapacityExceededException("message", ErrorType.Receiver, "errorCode", "requestId", HttpStatusCode.ServiceUnavailable) },
             };
         }
     }

--- a/Amazon.QLDB.Driver.Tests/RetryHandlerTests.cs
+++ b/Amazon.QLDB.Driver.Tests/RetryHandlerTests.cs
@@ -6,6 +6,7 @@ namespace Amazon.QLDB.Driver.Tests
     using System.Net;
     using Amazon.QLDBSession;
     using Amazon.QLDBSession.Model;
+    using Amazon.Runtime;
     using Microsoft.Extensions.Logging.Abstractions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -62,7 +63,7 @@ namespace Amazon.QLDB.Driver.Tests
             var defaultPolicy = Driver.RetryPolicy.Builder().Build();
             var customerPolicy = Driver.RetryPolicy.Builder().WithMaxRetries(10).Build();
 
-            var cee = new RetriableException("txnId11111", true, new CapacityExceededException("qldb"));
+            var cee = new RetriableException("txnId11111", true, new CapacityExceededException("qldb", ErrorType.Receiver, "errorCode", "requestId", HttpStatusCode.ServiceUnavailable));
             var occ = new RetriableException("txnId11111", true, new OccConflictException("qldb", new BadRequestException("oops")));
             var occFailedAbort = new RetriableException("txnId11111", false, new OccConflictException("qldb", new BadRequestException("oops")));
             var txnExpiry = new RetriableException("txnid1111111", false, new InvalidSessionException("Transaction 324weqr2314 has expired"));

--- a/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
+++ b/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
@@ -188,7 +188,7 @@
         private static void SetUserAgent(object sender, RequestEventArgs eventArgs)
         {
             const string UserAgentHeader = "User-Agent";
-            const string Version = "1.1.1";
+            const string Version = "1.1.0";
 
             if (!(eventArgs is WebServiceRequestEventArgs args) || !args.Headers.ContainsKey(UserAgentHeader))
             {

--- a/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
+++ b/Amazon.QLDB.Driver/driver/QldbDriverBuilder.cs
@@ -188,7 +188,7 @@
         private static void SetUserAgent(object sender, RequestEventArgs eventArgs)
         {
             const string UserAgentHeader = "User-Agent";
-            const string Version = "1.1.0";
+            const string Version = "1.1.1";
 
             if (!(eventArgs is WebServiceRequestEventArgs args) || !args.Headers.ContainsKey(UserAgentHeader))
             {

--- a/Amazon.QLDB.Driver/session/QldbSession.cs
+++ b/Amazon.QLDB.Driver/session/QldbSession.cs
@@ -134,10 +134,6 @@ namespace Amazon.QLDB.Driver
             {
                 throw new RetriableException(transactionId, occ);
             }
-            catch (CapacityExceededException cee)
-            {
-                throw new RetriableException(transaction.Id, this.TryAbort(transaction), cee);
-            }
             catch (AmazonServiceException ase)
             {
                 if (ase.StatusCode == HttpStatusCode.InternalServerError ||


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
-`CapacityExceededException` is a subtype of `AmazonServiceException` and contains a 503 status code which we already handle. Removed the explicit catch of `CapacityExceededException` and updated unit test to create `CapacityExceededException` with 503 status code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
