### PR TITLE
Enable the mapping of the raw IonBinary to another type

### DIFF
--- a/Amazon.QLDB.Driver/result/BaseIonEnumerator.cs
+++ b/Amazon.QLDB.Driver/result/BaseIonEnumerator.cs
@@ -13,7 +13,7 @@
 
 namespace Amazon.QLDB.Driver
 {
-    using System;
+    using System.IO;
     using System.Collections.Generic;
     using Amazon.IonDotnet.Builders;
     using Amazon.IonDotnet.Tree;
@@ -73,6 +73,15 @@ namespace Amazon.QLDB.Driver
                 return IonLoader.Load(this.currentEnumerator.Current.IonBinary).GetElementAt(0);
             }
         }
+
+        public Stream CurrentIonBinary
+        {
+            get
+            {
+                return this.currentEnumerator.Current.IonBinary;
+            }
+        }
+
 
         /// <summary>
         /// Gets the current query statistics for the number of read IO requests.

--- a/Amazon.QLDB.Driver/result/BufferedResult.cs
+++ b/Amazon.QLDB.Driver/result/BufferedResult.cs
@@ -13,8 +13,10 @@
 
 namespace Amazon.QLDB.Driver
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.IO;
     using Amazon.IonDotnet.Tree;
 
     /// <summary>
@@ -62,6 +64,11 @@ namespace Amazon.QLDB.Driver
         public IEnumerator<IIonValue> GetEnumerator()
         {
             return this.values.GetEnumerator();
+        }
+
+        public IEnumerable<R> Select<R>(Func<Stream, R> selector)
+        {
+            throw new NotImplementedException("Cannot Select a BufferedResult as the Stream is not available");
         }
 
         /// <summary>

--- a/Amazon.QLDB.Driver/result/IResult.cs
+++ b/Amazon.QLDB.Driver/result/IResult.cs
@@ -13,6 +13,8 @@
 
 namespace Amazon.QLDB.Driver
 {
+    using System;
+    using System.IO;
     using System.Collections.Generic;
     using Amazon.IonDotnet.Tree;
 
@@ -38,5 +40,7 @@ namespace Amazon.QLDB.Driver
         ///
         /// <returns>The current TimingInformation statistics.</returns>
         TimingInformation? GetTimingInformation();
+
+        IEnumerable<R> Select<R>(Func<Stream, R> selector);
     }
 }


### PR DESCRIPTION
Not planning to push this as is (there are no tests), creating PR for visibility.

This change adds a `Select` method to IResult so that we can get hold of the raw-unparsed Ion binary stream back from QLDB and then later therefore be able to map it onto an object of any type.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
