### PR TITLE
Expose transaction ID within Transaction Executor classes

### DIFF
--- a/Amazon.QLDB.Driver.IntegrationTests/AsyncStatementExecutionTests.cs
+++ b/Amazon.QLDB.Driver.IntegrationTests/AsyncStatementExecutionTests.cs
@@ -489,6 +489,21 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             Assert.AreEqual(1092, ioUsage?.ReadIOs);
             Assert.IsTrue(timingInfo?.ProcessingTimeMilliseconds > 0);
         }
+        
+        [TestMethod]
+        public async Task ExecuteAsync_ReturnTransactionIdAfterStatementExecution()
+        {
+            var query = $"SELECT * FROM {Constants.TableName}";
+            var txnId = await qldbDriver.Execute(async txn =>
+            {
+                await txn.Execute(query);
+
+                return txn.Id;
+            });
+            
+            Assert.IsNotNull(txnId);
+            Assert.IsTrue(txnId.Length > 0);
+        }
 
         private static async Task<bool> ConfirmTableExists(string tableName)
         {

--- a/Amazon.QLDB.Driver.IntegrationTests/StatementExecutionTests.cs
+++ b/Amazon.QLDB.Driver.IntegrationTests/StatementExecutionTests.cs
@@ -861,5 +861,20 @@ namespace Amazon.QLDB.Driver.IntegrationTests
             Assert.AreEqual(1092, ioUsage?.ReadIOs);
             Assert.IsTrue(timingInfo?.ProcessingTimeMilliseconds > 0);
         }
+
+        [TestMethod]
+        public void Execute_ReturnTransactionIdAfterStatementExecution()
+        {
+            var query = $"SELECT * FROM {Constants.TableName}";
+            var txnId = qldbDriver.Execute(txn =>
+            {
+                txn.Execute(query);
+
+                return txn.Id;
+            });
+            
+            Assert.IsNotNull(txnId);
+            Assert.IsTrue(txnId.Length > 0);
+        }
     }
 }

--- a/Amazon.QLDB.Driver/transaction/AsyncTransactionExecutor.cs
+++ b/Amazon.QLDB.Driver/transaction/AsyncTransactionExecutor.cs
@@ -39,6 +39,11 @@ namespace Amazon.QLDB.Driver
         }
 
         /// <summary>
+        /// Gets the transaction ID.
+        /// </summary>
+        public string Id => this.transaction.Id;
+
+        /// <summary>
         /// Execute the statement against QLDB and retrieve the result.
         /// </summary>
         ///

--- a/Amazon.QLDB.Driver/transaction/TransactionExecutor.cs
+++ b/Amazon.QLDB.Driver/transaction/TransactionExecutor.cs
@@ -38,6 +38,11 @@ namespace Amazon.QLDB.Driver
         }
 
         /// <summary>
+        /// Gets the transaction ID.
+        /// </summary>
+        public string Id => this.transaction.Id;
+
+        /// <summary>
         /// Abort the transaction and roll back any changes.
         /// </summary>
         public void Abort()


### PR DESCRIPTION
This PR allows users to access the transaction ID within a lambda execute function like so:

```c#
var txnId = qldbDriver.Execute(txn =>
{
    txn.Execute(query);

    return txn.Id;
});
```

Done for the sake of consistency with the other languages.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
