### PR TITLE
Add release GitHub action to sign Serialization DLL for release 

### DIFF
--- a/.github/workflows/release_driver.yml
+++ b/.github/workflows/release_driver.yml
@@ -8,39 +8,36 @@ on:
       - "v*.*.*"
       
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
       matrix:
         os: [windows-latest, macos-latest]
-        
-    steps:
-    - uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-        aws-region: us-east-2
+        dotnet: ['5.0.x']
 
-    - uses: actions/checkout@v2
-      with: 
-        submodules: recursive
-        
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Unit test
-      run: dotnet test Amazon.QLDB.Driver.Tests
-    - name: Integration test
-      run: dotnet test Amazon.QLDB.Driver.IntegrationTests --no-restore --verbosity normal --settings Amazon.QLDB.Driver.IntegrationTests/.runsettings
+    - steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+          
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Unit test
+        run: dotnet test Amazon.QLDB.Driver.Tests
+      - name: Integration test
+        run: dotnet test Amazon.QLDB.Driver.IntegrationTests --no-restore --verbosity normal --settings Amazon.QLDB.Driver.IntegrationTests/.runsettings
 
   release:
     name: Release
-    needs: [build]
+    needs: [test]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:
@@ -51,8 +48,8 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_SIGNING_ACCOUNT }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_SIGNING_ACCOUNT }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}

--- a/.github/workflows/release_driver.yml
+++ b/.github/workflows/release_driver.yml
@@ -18,7 +18,14 @@ jobs:
         os: [windows-latest, macos-latest]
         dotnet: ['5.0.x']
 
-    - steps:
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: us-east-2
+
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Setup .NET

--- a/.github/workflows/release_driver.yml
+++ b/.github/workflows/release_driver.yml
@@ -1,10 +1,16 @@
-name: Serialization Library Release
+name: QLDB Driver Release
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*.*.*"
       
 jobs:
   build:
     name: Build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
@@ -29,14 +35,17 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Unit test
       run: dotnet test Amazon.QLDB.Driver.Tests
+    - name: Integration test
+      run: dotnet test Amazon.QLDB.Driver.IntegrationTests --no-restore --verbosity normal --settings Amazon.QLDB.Driver.IntegrationTests/.runsettings
 
   release:
     name: Release
     needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ] 
+        os: [ ubuntu-latest ]
         dotnet: ['5.0.x']
       
     steps:
@@ -65,7 +74,7 @@ jobs:
           dotnet build --configuration Release
           
           # Push unsigned DLL to S3
-          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }} --body Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll  --acl bucket-owner-full-control | jq '.VersionId' )
+          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_DRIVER }} --body Amazon.QLDB.Driver/bin/Release/netstandard2.0/Amazon.QLDB.Driver.dll  --acl bucket-owner-full-control | jq '.VersionId' )
           
           job_id=""
           
@@ -74,7 +83,7 @@ jobs:
           for (( i=0; i<3; i++ ))
           do  
             # Get job ID
-            id=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }} --version-id ${version_id} | jq -r '.TagSet[0].Value' )
+            id=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_DRIVER }} --version-id ${version_id} | jq -r '.TagSet[0].Value' )
             if [ $id != "null" ]
             then
               job_id=$id
@@ -91,12 +100,12 @@ jobs:
           fi
 
           # Poll signed S3 bucket to see if the signed artifact is there
-          aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }}-${job_id}
+          aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_DRIVER }}-${job_id}
           
           # Get signed DLL from S3
-          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }}-${job_id} Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll
+          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_DRIVER }}-${job_id} Amazon.QLDB.Driver/bin/Release/netstandard2.0/Amazon.QLDB.Driver.dll
 
       - name: Publish to NuGet
         run: |
           dotnet pack --configuration Release --no-build
-          dotnet nuget push Amazon.QLDB.Driver.Serialization/bin/Release/Amazon.QLDB.Driver.Serialization.*.nupkg --api-key ${{ secrets.AWS_NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push Amazon.QLDB.Driver/bin/Release/Amazon.QLDB.Driver.*.nupkg --api-key ${{ secrets.AWS_NUGET_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -2,11 +2,15 @@ name: Serialization Library Release
 
 on:
   push:
+    branches:
+      - master
     tags:
       - "v*.*.*"
-
+      
 jobs:
   build:
+    name: Build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
@@ -32,8 +36,9 @@ jobs:
     - name: Integration test
       run: dotnet test Amazon.QLDB.Driver.IntegrationTests --no-restore --verbosity normal --settings Amazon.QLDB.Driver.IntegrationTests/.runsettings
 
-  sign:
-    name: Sign package
+  release:
+    name: Release
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [build]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -60,34 +65,25 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
         
-      - name: Create DLL
+      - name: Sign
         run: |
-          dotnet restore
-          dotnet build --configuration Release --no-restore
-        
-      - name: Push unsigned DLL to S3
-        id: get-version
-        run: |
-          version=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll  --acl bucket-owner-full-control | jq '.VersionId' )
-          echo "::set-output name=version-id::$version"
-      - name: Wait 5 seconds for job ID tag to be populated in S3 object
-        run: sleep 5s
-  
-      - name: Get job ID
-        id: get-job-id
-        run: |
-          job=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id ${{ steps.get-version.outputs.version-id }} | jq '.TagSet[0].Value' )
-          echo "::set-output name=job-id::$job"
-        
-      - name: Poll signed S3 bucket to see if the signed artifact is there
-        run: |
-          echo ${{ steps.get-job-id.outputs.job-id }}
-          aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${{ steps.get-job-id.outputs.job-id }}
-      
-      - name: Get signed DLL from S3
-        run: |
-          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${{ steps.get-job-id.outputs.job-id }} Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll
-      
+          dotnet build --configuration Release
+          
+          # Push unsigned DLL to S3
+          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll  --acl bucket-owner-full-control | jq '.VersionId' )
+          
+          # Wait 5 seconds for job ID tag to be populated in S3 object
+          sleep 5s
+          
+          # Get job ID
+          job_id=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id ${version_id} | jq -r '.TagSet[0].Value' )
+                  
+          # Poll signed S3 bucket to see if the signed artifact is there
+          aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id}
+          
+          # Get signed DLL from S3
+          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id} Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll
+
       - uses: actions/upload-artifact@v2
         with:
           name: signed-dll

--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -1,0 +1,94 @@
+name: Serialization Library Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        os: [windows-latest, macos-latest]
+        
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+        aws-region: us-east-2
+
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Unit test
+      run: dotnet test Amazon.QLDB.Driver.Tests
+    - name: Integration test
+      run: dotnet test Amazon.QLDB.Driver.IntegrationTests --no-restore --verbosity normal --settings Amazon.QLDB.Driver.IntegrationTests/.runsettings
+
+  sign:
+    name: Sign package
+    needs: [build]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ] 
+        dotnet: ['5.0.x']
+      
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_SIGNING_ACCOUNT }}
+          aws-secret-access-key: ${{ secrets.SIGNING_AWS_SECRET_ACCESS_KEY_SIGNING_ACCOUNT }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          role-duration-seconds: 900
+          
+      - name: Wait / Sleep
+        uses: jakejarvis/wait-action@v0.1.1
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+        
+      - name: Create DLL
+        run: |
+          dotnet restore
+          dotnet build --configuration Release --no-restore
+        
+      - name: Push unsigned DLL to S3
+        id: get-version
+        run: |
+          version=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll  --acl bucket-owner-full-control | jq '.VersionId' )
+          echo "::set-output name=version-id::$version"
+      - name: Wait 5 seconds for job ID tag to be populated in S3 object
+        run: sleep 5s
+  
+      - name: Get job ID
+        id: get-job-id
+        run: |
+          job=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id ${{ steps.get-version.outputs.version-id }} | jq '.TagSet[0].Value' )
+          echo "::set-output name=job-id::$job"
+        
+      - name: Poll signed S3 bucket to see if the signed artifact is there
+        run: |
+          echo ${{ steps.get-job-id.outputs.job-id }}
+          aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${{ steps.get-job-id.outputs.job-id }}
+      
+      - name: Get signed DLL from S3
+        run: |
+          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${{ steps.get-job-id.outputs.job-id }} Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll
+      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: signed-dll
+          path: Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll

--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -1,16 +1,10 @@
 name: Serialization Library Release
 
-on:
-  push:
-    branches:
-      - master
-    tags:
-      - "v*.*.*"
+on: workflow_dispatch
       
 jobs:
   build:
     name: Build
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
@@ -32,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore 
     - name: Unit test
       run: dotnet test Amazon.QLDB.Driver.Tests
     - name: Integration test
@@ -40,7 +34,6 @@ jobs:
 
   release:
     name: Release
-    if: startsWith(github.ref, 'refs/tags/')
     needs: [build]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -71,7 +64,7 @@ jobs:
         
       - name: Sign
         run: |
-          dotnet build --configuration Release
+          dotnet build --configuration Release ./Amazon.QLDB.Driver.Serialization/Amazon.QLDB.Driver.Serialization.csproj
           
           # Push unsigned DLL to S3
           version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll  --acl bucket-owner-full-control | jq '.VersionId' )

--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -76,12 +76,29 @@ jobs:
           # Push unsigned DLL to S3
           version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll  --acl bucket-owner-full-control | jq '.VersionId' )
           
-          # Wait 5 seconds for job ID tag to be populated in S3 object
-          sleep 5s
+          job_id=""
           
-          # Get job ID
-          job_id=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id ${version_id} | jq -r '.TagSet[0].Value' )
-                  
+          # Attempt to get Job ID from bucket tagging, will retry up to 3 times before exiting with a failure code.
+          # Will sleep for 5 seconds between retries.
+          for (( i=0; i<3; i++ ))
+          do  
+            # Get job ID
+            id=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id ${version_id} | jq -r '.TagSet[0].Value' )
+            if [ $id != "null" ]
+            then
+              job_id=$id
+              break
+            fi
+            
+            sleep 5s
+          done
+          
+          if [[ $job_id = "" ]]
+          then
+             echo "Exiting because unable to retrieve job ID"
+             exit 1
+          fi
+
           # Poll signed S3 bucket to see if the signed artifact is there
           aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id}
           

--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_SIGNING_ACCOUNT }}
-          aws-secret-access-key: ${{ secrets.SIGNING_AWS_SECRET_ACCESS_KEY_SIGNING_ACCOUNT }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_SIGNING_ACCOUNT }}
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}

--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -26,7 +26,9 @@ jobs:
         aws-region: us-east-2
 
     - uses: actions/checkout@v2
-
+      with: 
+        submodules: recursive
+        
     - name: Install dependencies
       run: dotnet restore
     - name: Build
@@ -60,6 +62,8 @@ jobs:
         uses: jakejarvis/wait-action@v0.1.1
       - name: Git Checkout
         uses: actions/checkout@v2
+        with: 
+          submodules: recursive
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -3,36 +3,33 @@ name: Serialization Library Release
 on: workflow_dispatch
       
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
       matrix:
         os: [windows-latest, macos-latest]
+        dotnet: ['5.0.x']
         
     steps:
-    - uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-        aws-region: us-east-2
-
-    - uses: actions/checkout@v2
-      with: 
-        submodules: recursive
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
         
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Unit test
-      run: dotnet test Amazon.QLDB.Driver.Tests
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Unit test
+        run: dotnet test Amazon.QLDB.Driver.Tests
 
   release:
     name: Release
-    needs: [build]
+    needs: [test]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -42,8 +39,8 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_SIGNING_ACCOUNT }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_SIGNING_ACCOUNT }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is to demonstrate the integration of the Ion Object mapper library and the AWS signer service(for security reviewer).

We created a GitHub action to automate the release from signing the DLL to publishing to NuGet.

The high level workflow is:
1. Build the library (which will produce unsigned DLL)
2. Push the unsigned DLL into designated unsigned S3 bucket (this will trigger the signing job)
3. Poll the signed bucket to see if the signed DLL appears
4. Fetch the signed DLL from designated signed S3 bucket

Tested successfully on my [fork](https://github.com/byronlin13/amazon-qldb-driver-dotnet/actions/runs/1031842284)

Whats remaining:
* Package the signed DLL and push to NuGet

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
