### PR TITLE
Use IonObjectMapper v0.1.1 in Serialization Library

### DIFF
--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ] 
-        dotnet: ['5.0.x']
+        dotnet: ['3.1.x']
       
     steps:
       - uses: aws-actions/configure-aws-credentials@v1
@@ -57,7 +57,7 @@ jobs:
           dotnet build Amazon.QLDB.Driver.Serialization.sln --configuration Release
           
           # Push unsigned DLL to S3
-          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }} --body Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll  --acl bucket-owner-full-control | jq '.VersionId' )
+          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }} --body Amazon.QLDB.Driver.Serialization/bin/Release/netcoreapp3.1/Amazon.QLDB.Driver.Serialization.dll  --acl bucket-owner-full-control | jq '.VersionId' )
           
           job_id=""
           
@@ -86,7 +86,7 @@ jobs:
           aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }}-${job_id}
           
           # Get signed DLL from S3
-          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }}-${job_id} Amazon.QLDB.Driver.Serialization/bin/Release/net5.0/Amazon.QLDB.Driver.Serialization.dll
+          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY_SERIALIZATION }}-${job_id} Amazon.QLDB.Driver.Serialization/bin/Release/netcoreapp3.1/Amazon.QLDB.Driver.Serialization.dll
 
       - name: Publish to NuGet
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.vscode/
 bin/
 obj/
 *.ncrunchsolution

--- a/Amazon.QLDB.Driver.Serialization/Amazon.QLDB.Driver.Serialization.csproj
+++ b/Amazon.QLDB.Driver.Serialization/Amazon.QLDB.Driver.Serialization.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
-    <Version>0.1.0</Version>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <Version>0.1.1</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Company>Amazon.com, Inc.</Company>
     <Authors>Amazon Web Services</Authors>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonObjectMapper" Version="0.1.0" />
+    <PackageReference Include="Amazon.IonObjectMapper" Version="0.1.1" />
     <PackageReference Include="Amazon.QLDB.Driver" Version="1.3.0" />
     <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.2" />
   </ItemGroup>

--- a/Amazon.QLDB.Driver.Serialization/Document.cs
+++ b/Amazon.QLDB.Driver.Serialization/Document.cs
@@ -18,6 +18,6 @@ namespace Amazon.QLDB.Driver.Serialization
     /// </summary>
     public class Document
     {
-        public string DocumentId { get; init; }
+        public string DocumentId { get; set; }
     }
 }


### PR DESCRIPTION
*Description of changes:*
Use IonObjectMapper v0.1.1 in Serialization Library 
and bump version to 0.1.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
