### PR TITLE
Update test

### DIFF
--- a/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
+++ b/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>

--- a/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
+++ b/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.QLDB.Driver.Serialization" Version="0.1.0" />
+    <PackageReference Include="Amazon.QLDB.Driver.Serialization" Version="0.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.csproj
+++ b/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>

--- a/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.csproj
+++ b/Amazon.QLDB.Driver.Tests/Amazon.QLDB.Driver.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
*Description of changes:*
Add `.NET Core 3.1` target in unit and integration tests and bump Serialization dependency version to `0.1.1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
