### PR TITLE
Bump version to 0.1.2 and use v0.1.2 Ion Object Mapper

### DIFF
--- a/Amazon.QLDB.Driver.Serialization/Amazon.QLDB.Driver.Serialization.csproj
+++ b/Amazon.QLDB.Driver.Serialization/Amazon.QLDB.Driver.Serialization.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Company>Amazon.com, Inc.</Company>
     <Authors>Amazon Web Services</Authors>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonObjectMapper" Version="0.1.1" />
+    <PackageReference Include="Amazon.IonObjectMapper" Version="0.1.2" />
     <PackageReference Include="Amazon.QLDB.Driver" Version="1.3.0" />
     <PackageReference Include="AWSSDK.QLDBSession" Version="3.5.2" />
   </ItemGroup>


### PR DESCRIPTION
*Description of changes:*
Bump version to 0.1.2 and use v0.1.2 Ion Object Mapper

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
