### PR TITLE
Add tests to serialization library

### DIFF
--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -7,7 +7,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         os: [windows-latest, macos-latest]
         
@@ -19,8 +19,8 @@ jobs:
         run: dotnet restore Amazon.QLDB.Driver.Serialization.sln
       - name: Build
         run: dotnet build Amazon.QLDB.Driver.Serialization.sln --configuration Release --no-restore
-#      TODO: Add Serialization tests
-#      - name: Unit test
+      - name: Unit Test
+        run: dotnet test Amazon.QLDB.Driver.Serialization.Tests
 
   release:
     name: Release

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bin/
 obj/
 *.ncrunchsolution
 *.user
+docs/_site.zip
+global.json

--- a/Amazon.QLDB.Driver.Serialization.Tests/Amazon.QLDB.Driver.Serialization.Tests.csproj
+++ b/Amazon.QLDB.Driver.Serialization.Tests/Amazon.QLDB.Driver.Serialization.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+        <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Amazon.QLDB.Driver.Serialization\Amazon.QLDB.Driver.Serialization.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Amazon.QLDB.Driver.Serialization.Tests/ObjectSerializerTests.cs
+++ b/Amazon.QLDB.Driver.Serialization.Tests/ObjectSerializerTests.cs
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+namespace Amazon.QLDB.Driver.Serialization.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    class Person
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+
+        public override string ToString()
+        {
+            return "<Person>{ Name: " + Name + ", Age: " + Age + " }";
+        }
+    }
+
+    [TestClass]
+    public class ObjectSerializerTests
+    {
+        private static readonly Person John = new Person { Name = "John", Age = 13 };
+
+        [TestMethod]
+        public void TestSerde()
+        {
+            ObjectSerializer serializer = new ObjectSerializer();
+            Person testPerson = serializer.Deserialize<Person>(serializer.Serialize(John));
+
+            Assert.AreEqual(John.ToString(), testPerson.ToString());
+        }
+    }
+}
+
+

--- a/Amazon.QLDB.Driver.Serialization.sln
+++ b/Amazon.QLDB.Driver.Serialization.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.31410.357
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.QLDB.Driver.Serialization", "Amazon.QLDB.Driver.Serialization\Amazon.QLDB.Driver.Serialization.csproj", "{609F769E-D6EF-4F5E-920E-EE678211EFB2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.QLDB.Driver.Serialization.Tests", "Amazon.QLDB.Driver.Serialization.Tests\Amazon.QLDB.Driver.Serialization.Tests.csproj", "{8AF6527C-8AAE-4060-8A7D-E5556F17BC74}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{609F769E-D6EF-4F5E-920E-EE678211EFB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{609F769E-D6EF-4F5E-920E-EE678211EFB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{609F769E-D6EF-4F5E-920E-EE678211EFB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8AF6527C-8AAE-4060-8A7D-E5556F17BC74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8AF6527C-8AAE-4060-8A7D-E5556F17BC74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8AF6527C-8AAE-4060-8A7D-E5556F17BC74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8AF6527C-8AAE-4060-8A7D-E5556F17BC74}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Amazon.QLDB.Driver.Serialization/ObjectSerializer.cs
+++ b/Amazon.QLDB.Driver.Serialization/ObjectSerializer.cs
@@ -55,13 +55,9 @@ namespace Amazon.QLDB.Driver.Serialization
         /// <returns>The ValueHolder object containing the Ion binary.</returns>
         public ValueHolder Serialize(object o)
         {
-            MemoryStream memoryStream = new MemoryStream();
-            serializer.Serialize(memoryStream, o);
-            memoryStream.Flush();
-            memoryStream.Position = 0;
             return new ValueHolder
             {
-                IonBinary = memoryStream,
+                IonBinary = (MemoryStream) serializer.Serialize(o),
             };
         }
     }


### PR DESCRIPTION
*Description of changes:*
Add tests to serialization library. The tests only verify the basic serde works for `ObjectSerializer` class, since it's just a wrapper of the Ion Object Mapper and the thorough tests for serde behavior should be done on object mapper side.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
