### PR TITLE
Allow custom serialization options

### DIFF
--- a/Amazon.QLDB.Driver.Serialization/ObjectSerializer.cs
+++ b/Amazon.QLDB.Driver.Serialization/ObjectSerializer.cs
@@ -34,6 +34,16 @@ namespace Amazon.QLDB.Driver.Serialization
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectSerializer"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">Serialization options for customizing serializer behavior.</param>
+        public ObjectSerializer(IonSerializationOptions options)
+        {
+            serializer = new IonSerializer(options);
+        }
+
+        /// <summary>
         /// Deserialize a ValueHolder object containing the Ion binary into an object of type T.
         /// </summary>
         ///


### PR DESCRIPTION
*Description of changes:*
Allow custom serialization options to be passed in `ObjectSerializer` to enable further customizing behavior when using object mapper in driver 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
