### PR TITLE
workflows: explicitly set dotnet version

### DIFF
--- a/.github/workflows/dotnetapp.yml
+++ b/.github/workflows/dotnetapp.yml
@@ -13,6 +13,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [windows-latest, macos-latest]
+        dotnet: ['3.1.x']
 
     steps:
     - uses: aws-actions/configure-aws-credentials@v1
@@ -23,6 +24,11 @@ jobs:
         aws-region: us-east-2
 
     - uses: actions/checkout@v2
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: ${{ matrix.dotnet }}
 
     - name: Install dependencies
       run: dotnet restore Amazon.QLDB.Driver.sln

--- a/.github/workflows/release_driver.yml
+++ b/.github/workflows/release_driver.yml
@@ -16,6 +16,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [windows-latest, macos-latest]
+        dotnet: ['3.1.x']
 
     steps:
       - uses: aws-actions/configure-aws-credentials@v1
@@ -27,6 +28,11 @@ jobs:
 
       - name: Git checkout
         uses: actions/checkout@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
           
       - name: Install dependencies
         run: dotnet restore Amazon.QLDB.Driver.sln
@@ -45,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        dotnet: ['5.0.x']
+        dotnet: ['3.1.x']
       
     steps:
       - uses: aws-actions/configure-aws-credentials@v1
@@ -64,7 +70,7 @@ jobs:
         with: 
           submodules: recursive
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: ${{ matrix.dotnet }}
         

--- a/.github/workflows/release_serialization.yml
+++ b/.github/workflows/release_serialization.yml
@@ -10,10 +10,16 @@ jobs:
       max-parallel: 2
       matrix:
         os: [windows-latest, macos-latest]
+        dotnet: ['3.1.x']
         
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
         
       - name: Install dependencies
         run: dotnet restore Amazon.QLDB.Driver.Serialization.sln
@@ -49,7 +55,7 @@ jobs:
         with: 
           submodules: recursive
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: ${{ matrix.dotnet }}
         

--- a/Amazon.QLDB.Driver.Tests/AsyncQldbDriverTests.cs
+++ b/Amazon.QLDB.Driver.Tests/AsyncQldbDriverTests.cs
@@ -234,7 +234,7 @@ namespace Amazon.QLDB.Driver.Tests
                 mockClient.QueueResponse(ex);
 
                 // OccConflictException reuses the session so no need for another start session.
-                if (ex is not OccConflictException)
+                if (!(ex is OccConflictException))
                 {
                     mockClient.QueueResponse(StartSessionResponse(TestRequestId));
                 }

--- a/Amazon.QLDB.Driver.Tests/AsyncResultTests.cs
+++ b/Amazon.QLDB.Driver.Tests/AsyncResultTests.cs
@@ -27,35 +27,35 @@ namespace Amazon.QLDB.Driver.Tests
     {
         private static AsyncResult result;
         private static Mock<Session> mockSession;
-        private static readonly MemoryStream MemoryStream = new();
-        private static readonly ValueHolder ValueHolder = new()
+        private static readonly MemoryStream MemoryStream = new MemoryStream();
+        private static readonly ValueHolder ValueHolder = new ValueHolder
         {
             IonBinary = MemoryStream,
             IonText = "ionText"
         };
-        private static readonly List<ValueHolder> ValueHolderList = new() { ValueHolder };
+        private static readonly List<ValueHolder> ValueHolderList = new List<ValueHolder>() { ValueHolder };
 
         private static readonly long ExecuteReads = 1;
         private static readonly long ExecuteWrites = 2;
         private static readonly long ExecuteTime = 100;
-        private static readonly IOUsage ExecuteIO = new()
+        private static readonly IOUsage ExecuteIO = new IOUsage
         {
             ReadIOs = ExecuteReads,
             WriteIOs = ExecuteWrites
         };
-        private static readonly TimingInformation ExecuteTiming = new()
+        private static readonly TimingInformation ExecuteTiming = new TimingInformation
         {
             ProcessingTimeMilliseconds = ExecuteTime
         };
         private static readonly long FetchReads = 10;
         private static readonly long FetchWrites = 20;
         private static readonly long FetchTime = 1000;
-        private static readonly IOUsage FetchIO = new()
+        private static readonly IOUsage FetchIO = new IOUsage
         {
             ReadIOs = FetchReads,
             WriteIOs = FetchWrites
         };
-        private static readonly TimingInformation FetchTiming = new()
+        private static readonly TimingInformation FetchTiming = new TimingInformation
         {
             ProcessingTimeMilliseconds = FetchTime
         };
@@ -89,7 +89,7 @@ namespace Amazon.QLDB.Driver.Tests
         public async Task TestAsyncMoveNextWithOneNextPage()
         {
             var ms = new MemoryStream();
-            var valueHolderList = new List<ValueHolder> { new() { IonBinary = ms, IonText = "ionText" } };
+            var valueHolderList = new List<ValueHolder> { new ValueHolder { IonBinary = ms, IonText = "ionText" } };
             var fetchPageResult = new FetchPageResult
             {
                 Page = new Page { NextPageToken = null, Values = valueHolderList }
@@ -114,7 +114,7 @@ namespace Amazon.QLDB.Driver.Tests
         public async Task TestAsyncMoveNextWithNoNextPage()
         {
             var ms = new MemoryStream();
-            var valueHolderList = new List<ValueHolder> { new() { IonBinary = ms, IonText = "ionText" } };
+            var valueHolderList = new List<ValueHolder> { new ValueHolder { IonBinary = ms, IonText = "ionText" } };
             var executeResult = new ExecuteStatementResult
             {
                 FirstPage = new Page

--- a/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
+++ b/Amazon.QLDB.Driver.Tests/QldbDriverTests.cs
@@ -295,7 +295,7 @@ namespace Amazon.QLDB.Driver.Tests
                 mockClient.QueueResponse(ex);
 
                 // OccConflictException reuses the session so no need for another start session.
-                if (ex is not OccConflictException)
+                if (!(ex is OccConflictException))
                 {
                     mockClient.QueueResponse(StartSessionResponse(TestRequestId));
                 }

--- a/Amazon.QLDB.Driver/result/BaseIonEnumerator.cs
+++ b/Amazon.QLDB.Driver/result/BaseIonEnumerator.cs
@@ -97,8 +97,12 @@ namespace Amazon.QLDB.Driver
         /// <returns>The current TimingInformation statistics.</returns>
         internal TimingInformation? GetTimingInformation()
         {
-            return this.processingTimeMilliseconds == null ? null :
-                new TimingInformation(this.processingTimeMilliseconds.Value);
+            if (this.processingTimeMilliseconds != null)
+            {
+                return new TimingInformation(this.processingTimeMilliseconds.Value);
+            }
+
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
Mitigates https://github.com/NuGet/Announcements/issues/62 by specifying .NET versions in the workflows. As per actions/setup-dotnet, this should pull the most recent version of .NET that matches the specifier.

In order to build with the .NET Core 3.1 SDK, we also have to downgrade the language version, so this PR also removes some higher-version language features to match source compatibility with 3.1