### PR TITLE
update default backoff jitter algo base

### DIFF
--- a/Amazon.QLDB.Driver.Tests/ExponentBackoffStrategyTests.cs
+++ b/Amazon.QLDB.Driver.Tests/ExponentBackoffStrategyTests.cs
@@ -7,10 +7,10 @@ namespace Amazon.QLDB.Driver.Tests
     [TestClass]
     class ExponentBackoffStrategyTests
     {
-        [DataRow(1, 10)]
-        [DataRow(2, 100)]
-        [DataRow(3, 1000)]
-        [DataRow(4, 5000)]
+        [DataRow(1, 20)]
+        [DataRow(2, 40)]
+        [DataRow(3, 80)]
+        [DataRow(4, 160)]
         [DataTestMethod]
         public void CalculateDelay_ForGivenRetryAttempts_ReturnExpectedDelay(int retryAttempted, int expectedMax)
         {

--- a/Amazon.QLDB.Driver/retry/ExponentBackoffStrategy.cs
+++ b/Amazon.QLDB.Driver/retry/ExponentBackoffStrategy.cs
@@ -59,7 +59,7 @@ namespace Amazon.QLDB.Driver
         public TimeSpan CalculateDelay(RetryPolicyContext retryPolicyContext)
         {
             var jitterRand = (new Random().NextDouble() * 0.5) + 0.5;
-            var exponentialBackoff = Math.Min(this.sleepCapMilliseconds, Math.Pow(this.sleepBaseMilliseconds, retryPolicyContext.RetriesAttempted));
+            var exponentialBackoff = Math.Min(this.sleepCapMilliseconds, this.sleepBaseMilliseconds * Math.Pow(2, retryPolicyContext.RetriesAttempted));
 
             return TimeSpan.FromMilliseconds(jitterRand * exponentialBackoff);
         }


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Part of qldb driver implementation sync for retries. QLDB drivers implemented full jitter slightly differently.
jitter algorithm is sleep_base * 2 ** retry_attempts
was implemented as sleep_base ** retry_attempt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
