### PR TITLE
WIP: Add SHA256.Create() for AOT builds

### DIFF
--- a/Amazon.QLDB.Driver/utils/QldbHash.cs
+++ b/Amazon.QLDB.Driver/utils/QldbHash.cs
@@ -30,6 +30,7 @@ namespace Amazon.QLDB.Driver
     internal class QldbHash
     {
         private const int HashSize = 32;
+        private static readonly HashAlgorithm Sha256Algorithm = SHA256.Create();
         private static readonly IIonHasherProvider HasherProvider = new CryptoIonHasherProvider("SHA256");
         private static readonly IValueFactory ValueFactory = new ValueFactory();
 


### PR DESCRIPTION
*Issue #197*

*Description of changes:* 
As a work around of the [IonHash Dotnet](https://github.com/amazon-ion/ion-hash-dotnet) library using the generic hash algorithm provider being trimmed during AOT compilation. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
