### PR TITLE
Update ion-object-mapper and bump version to 1.0.1

### DIFF
--- a/Amazon.QLDB.Driver.Serialization/Amazon.QLDB.Driver.Serialization.csproj
+++ b/Amazon.QLDB.Driver.Serialization/Amazon.QLDB.Driver.Serialization.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Company>Amazon.com, Inc.</Company>
     <Authors>Amazon Web Services</Authors>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonObjectMapper" Version="1.0.0" />
+    <PackageReference Include="Amazon.IonObjectMapper" Version="1.0.1" />
     <PackageReference Include="Amazon.QLDB.Driver" Version="1.4.1" />
     <PackageReference Include="AWSSDK.QLDBSession" Version="3.7.100.84" />
   </ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Update ObjectMapper dependency to v1.0.1 and use the latest version of ion-object-mapper. **This PR can only be merged after the v1.0.1 release of ObjectMapper**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
