### PR TITLE
Update serialization library version in integration tests

### DIFF
--- a/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
+++ b/Amazon.QLDB.Driver.IntegrationTests/Amazon.QLDB.Driver.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.QLDB.Driver.Serialization" Version="1.0.0" />
+    <PackageReference Include="Amazon.QLDB.Driver.Serialization" Version="1.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update latest serialization library version to `1.0.1` to run integ tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
